### PR TITLE
feat(codeclimat): add php mass detector plugin with default settings

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -10,6 +10,11 @@ plugins:
     enabled: true
     tests:
       - tests/**
+  phpmd:
+    enabled: true
+    config:
+      file_extensions:
+        - php
 exclude_patterns:
 - "tests/"
 - "spec/"


### PR DESCRIPTION
Добавил еще одну настройку, которая есть для пхп -- php Mess Detector, он ищет потенциальные проблемы, неиспользуемые методы, если этих методов слишком много и т.д. и т.п.

Пока включил с дефолтными параметрами