### PR TITLE
Fix usertableseeder

### DIFF
--- a/app/Helpers/ChapterHelper.php
+++ b/app/Helpers/ChapterHelper.php
@@ -5,7 +5,7 @@ use Illuminate\Support\Collection;
 if (!function_exists('getChapterName')) {
     function getChapterName(string $chapter): string
     {
-        return  __('sicp.chapters')[$chapter] ?? __('sicp.chapters.'.$chapter);
+        return  __('sicp.chapters')[$chapter] ?? __('sicp.chapters.' . $chapter);
     }
 }
 

--- a/app/Helpers/ChapterHelper.php
+++ b/app/Helpers/ChapterHelper.php
@@ -5,7 +5,7 @@ use Illuminate\Support\Collection;
 if (!function_exists('getChapterName')) {
     function getChapterName(string $chapter): string
     {
-        return  __('sicp.chapters')[$chapter] ?? $chapter;
+        return  __('sicp.chapters')[$chapter] ?? __('sicp.chapters.'.$chapter);
     }
 }
 

--- a/app/Helpers/ChapterHelper.php
+++ b/app/Helpers/ChapterHelper.php
@@ -5,7 +5,7 @@ use Illuminate\Support\Collection;
 if (!function_exists('getChapterName')) {
     function getChapterName(string $chapter): string
     {
-        return  __('sicp.chapters')[$chapter];
+        return  __('sicp.chapters')[$chapter] ?? $chapter;
     }
 }
 

--- a/database/seeds/UsersTableSeeder.php
+++ b/database/seeds/UsersTableSeeder.php
@@ -14,9 +14,11 @@ class UsersTableSeeder extends Seeder
      */
     public function run()
     {
-        factory(User::class, 10)->create()->each(function (User $user) {
-            $chapters = Chapter::inRandomOrder()->limit(rand(5, 10))->get();
-            $user->chapters()->attach($chapters);
+        $chapters = Chapter::all();
+        factory(User::class, 10)->create()->each(function (User $user) use ($chapters) {
+            $user->chapters()->attach(
+                $chapters ->random(rand(5, 10))
+            );
         });
     }
 }


### PR DESCRIPTION
1.  Чтение таблицы вытащено из цикла, это дает небольшое общее ускорение тестов на 5-10 секунд.
2.  Текст по умолчанию, если имя каталога отсутствует в файле перевода. Это необходимо для построения относительно быстрой модели тестов, генерации случайных значений.

Следующим этапом будет реализация seeder для тестов.