### PR TITLE
fix #119

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -23,8 +23,10 @@ class RouteServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
-
+        Route::patterns([
+            'chapter' => '[0-9]+',
+            'user'    => '[0-9]+'
+        ]);
         parent::boot();
     }
 

--- a/tests/Feature/Http/Controllers/ChapterControllerTest.php
+++ b/tests/Feature/Http/Controllers/ChapterControllerTest.php
@@ -5,13 +5,19 @@ namespace Tests\Feature\Http\Controllers;
 use App\Chapter;
 use Tests\TestCase;
 use App\User;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class ChapterControllerTest extends TestCase
 {
     protected function setUp(): void
     {
         parent::setUp();
-        $this->seed('TestDatabaseSeeder');
+        factory(Chapter::class, 2)
+            ->create()
+            ->each(function (Chapter $chapter) {
+                $chapter->children()->saveMany(factory(Chapter::class, mt_rand(0, 3)));
+                factory(Chapter::class, mt_rand(0, 3))->create();
+            });
     }
 
     public function testIndexAsGuest()
@@ -37,5 +43,12 @@ class ChapterControllerTest extends TestCase
         $response = $this->get(route('chapters.show', $chapter));
 
         $response->assertStatus(200);
+    }
+
+    public function testInvalidShow()
+    {
+        $this->expectException(NotFoundHttpException::class);
+        $response = $this->get(route('chapters.show', ['chapter' => 'foo']));
+        $response->assertNotFound();
     }
 }

--- a/tests/Feature/Http/Controllers/UserControllerTest.php
+++ b/tests/Feature/Http/Controllers/UserControllerTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Http\Controllers;
 
 use App\User;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Tests\TestCase;
 
 class UserControllerTest extends TestCase
@@ -41,5 +42,13 @@ class UserControllerTest extends TestCase
 
         $response->assertStatus(200)
             ->assertSee(e($user->name));
+    }
+
+    public function testInvalidShow()
+    {
+        $this->expectException(NotFoundHttpException::class);
+        $response = $this->get(route('users.show', ['user' => 'foo']));
+        $response->assertNotFound();
+        $response->assertStatus(404);
     }
 }


### PR DESCRIPTION
Почему-то на постгресе возвращает 500 ошибку, когда вместо айдишника подставляются строковые значения.