### PR TITLE
Fix double link

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -60,6 +60,7 @@ class Kernel extends HttpKernel
         'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+        'localizationRedirect'    => \Mcamara\LaravelLocalization\Middleware\LaravelLocalizationRedirectFilter::class,
     ];
 
     /**

--- a/config/laravellocalization.php
+++ b/config/laravellocalization.php
@@ -325,7 +325,7 @@ return [
     // If `useAcceptLanguageHeader` is true, then the first time
     // the locale will be determined from browser and redirect to that language.
     // After that, `hideDefaultLocaleInURL` behaves as usual.
-    'hideDefaultLocaleInURL' => false,
+    'hideDefaultLocaleInURL' => true,
 
     // If you want to display the locales in particular order in the language selector you should write the order here.
     //CAUTION: Please consider using the appropriate locale code otherwise it will not work

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,8 +3,8 @@
 Route::get('sitemap.xml', 'SitemapController@index');
 
 Route::group([
-	'prefix' => LaravelLocalization::setLocale(),
-	'middleware' => [ 'localizationRedirect' ]
+    'prefix' => LaravelLocalization::setLocale(),
+    'middleware' => [ 'localizationRedirect' ]
 ], function () {
     Auth::routes(['verify' => true]);
     Route::resource('/', 'WelcomeController')->only('index');

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,7 +2,10 @@
 
 Route::get('sitemap.xml', 'SitemapController@index');
 
-Route::group(['prefix' => LaravelLocalization::setLocale()], function () {
+Route::group([
+	'prefix' => LaravelLocalization::setLocale(),
+	'middleware' => [ 'localizationRedirect' ]
+], function () {
     Auth::routes(['verify' => true]);
     Route::resource('/', 'WelcomeController')->only('index');
     Route::group(

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,7 +4,7 @@ Route::get('sitemap.xml', 'SitemapController@index');
 
 Route::group([
     'prefix' => LaravelLocalization::setLocale(),
-    'middleware' => [ 'localizationRedirect' ]
+    'middleware' => [ 'localizationRedirect' ],
 ], function () {
     Auth::routes(['verify' => true]);
     Route::resource('/', 'WelcomeController')->only('index');


### PR DESCRIPTION
Удалено дублирование страниц, теперь не /en/chapters, а /chapters
Пример на https://geozhur-sicp.herokuapp.com/