### PR TITLE
Added DB profiles for testing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,22 @@ $ php artisan migrate --seed
 * Чтобы включить логирование Rollbar, необходимо установить переменную `LOG_CHANNEL=rollbar` и `ROLLBAR_TOKEN=`
 * Чтобы добавить упражнение необходимо добавить его содержимое (код или картинка) по пути `resources/views/exercise/listing/#_#.blade.php`, а текстовое описание в `resources/lang/{locale}/sicp.php` под ключем `exercises.#.#` на соответствующем языке.
 
-##### 
-Добавить пре-комит хук
+#### Альтернативный профиль БД для тестирования
+
+1. Создать отдельную тестовую базу postgres.  
+Настройки параметров подключения можно посмотреть в секции `pgsql_test` конфигурации `config/database.php`
+Пример создания тестовой базы "с нуля":
+```shell
+sudo apt install postgresql
+sudo -u postgres createuser --createdb $(whoami)
+sudo -u postgres createuser hexlet_sicp_test_user
+sudo -u postgres psql -c "ALTER USER hexlet_sicp_test_user WITH ENCRYPTED PASSWORD 'secret'"
+createdb hexlet_sicp_test
+```
+2. Запустить тесты с альтернативным профилем `DB_CONNECTION=pgsql_test make test`
+
+#### Добавить пре-комит хук
+
 ```shell
 $ git config core.hooksPath .githooks
 ```

--- a/config/database.php
+++ b/config/database.php
@@ -91,6 +91,28 @@ return [
             'prefix_indexes' => true,
         ],
 
+        'sqlite_test' => [
+            'driver' => 'sqlite',
+            'url' => env('TEST_DATABASE_URL'),
+            'database' => env('TEST_DB_DATABASE', ':memory:'),
+            'prefix' => '',
+            'foreign_key_constraints' => env('TEST_DB_FOREIGN_KEYS', true),
+        ],
+
+        'pgsql_test' => [
+            'driver' => 'pgsql',
+            'url' => env('TEST_DATABASE_URL'),
+            'host' => env('TEST_DB_HOST', '127.0.0.1'),
+            'port' => env('TEST_DB_PORT', '5432'),
+            'database' => env('TEST_DB_DATABASE', 'hexlet_sicp_test'),
+            'username' => env('TEST_DB_USERNAME', 'hexlet_sicp_test_user'),
+            'password' => env('TEST_DB_PASSWORD', 'secret'),
+            'charset' => 'utf8',
+            'prefix' => '',
+            'prefix_indexes' => true,
+            'schema' => 'public',
+            'sslmode' => 'prefer',
+        ],
     ],
 
     /*

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -24,8 +24,7 @@
     </filter>
     <php>
         <env name="APP_ENV" value="testing"/>
-        <env name="DB_CONNECTION" value="sqlite"/>
-        <env name="DB_DATABASE" value=":memory:"/>
+        <env name="DB_CONNECTION" value="sqlite_test"/>
         <env name="CACHE_DRIVER" value="array"/>
         <env name="MAIL_DRIVER" value="array"/>
         <env name="QUEUE_DRIVER" value="sync"/>

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,13 +2,13 @@
 
 namespace Tests;
 
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
-    use DatabaseMigrations;
+    use RefreshDatabase;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
По мотивам [https://github.com/Hexlet/hexlet-sicp/issues/121](url), настроил два профиля для тестовой БД. Можно запускать тесты на postgres c откатом по транзакции. Доп. информацию по этому поводу добавил в README.md
`DB_CONNECTION=pgsql_test make test`

* Если других участников устроит, то в будущем можно будет сделать `pgsql_test` основным профилем для тестов. 
* Могу добавить установку альтернативной тестовой БД через Makefile. 