### PR TITLE
Remove env() call from views

### DIFF
--- a/config/google.php
+++ b/config/google.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'tag_manager' => [
+        'key' => env('GOOGLE_TAG_MANAGER_KEY'),
+    ],
+];

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -13,7 +13,7 @@
 
     <!-- Scripts -->
     <script src="{{ asset('js/app.js') }}" defer></script>
-    @if (env('APP_ENV') == 'production')
+    @if (config('app.env') == 'production')
     @include('layouts.deps._gtm_head')
     @endif
 
@@ -26,7 +26,7 @@
 </head>
 
 <body class="d-flex flex-column">
-    @if (env('APP_ENV') == 'production')
+    @if (config('app.env') == 'production')
     @include('layouts.deps._gtm_body')
     @endif
     <div class="d-flex flex-column min-vh-100">

--- a/resources/views/layouts/deps/_gtm_body.blade.php
+++ b/resources/views/layouts/deps/_gtm_body.blade.php
@@ -1,1 +1,1 @@
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ env('GOOGLE_TAG_MANAGER_KEY') }}" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ config('google.tag_manager.key') }}" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/resources/views/layouts/deps/_gtm_head.blade.php
+++ b/resources/views/layouts/deps/_gtm_head.blade.php
@@ -2,4 +2,4 @@
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','{{ env('GOOGLE_TAG_MANAGER_KEY') }}');</script>
+})(window,document,'script','dataLayer','{{ config('google.tag_manager.key') }}');</script>


### PR DESCRIPTION
Убрал вызовы хелпера `env()` вне файлов конфигурации.
Такие вызовы `env()` будут работать некорректно при кэшировании конфигурации.

Можно почитать тут:
[https://laravel.com/docs/6.x/configuration#configuration-caching](https://laravel.com/docs/6.x/configuration#configuration-caching)
[https://andy-carter.com/blog/env-gotcha-in-laravel-when-caching-configuration](https://andy-carter.com/blog/env-gotcha-in-laravel-when-caching-configuration)