### PR TITLE
upgrade README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 test:
 	composer run phpunit
 
-setup: env-prepare sqlite-prepare install key
+setup: env-prepare sqlite-prepare install key db-prepare
 
 install:
 	composer install
@@ -10,6 +10,9 @@ install:
 start:
 	heroku local -f Procfile.dev
 
+db-prepare:
+	php artisan migrate --seed
+	
 analyse:
 	php artisan code:analyse
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ### Requirements
 
-* PHP
+* PHP ^7.3
 * Composer
 * SQLite for local, PostgreSQL for production
 * [heroku cli](https://devcenter.heroku.com/articles/heroku-cli#download-and-install)

--- a/README.md
+++ b/README.md
@@ -21,9 +21,8 @@
 
 ```sh
 $ make setup
+$ make start # start server http://127.0.0.1:8000/
 $ make test # run tests
-$ make start # start server
-$ php artisan migrate --seed
 ```
 
 ### Смысл

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 
 * PHP ^7.3
 * Composer
+* Node.js & npm
 * SQLite for local, PostgreSQL for production
 * [heroku cli](https://devcenter.heroku.com/articles/heroku-cli#download-and-install)
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 ### Requirements
 
 * PHP ^7.3
+* Packages: php7.3-mbstring php7.3-curl php7.3-dom php7.3-xml php7.3-zip php7.3-sqlite (or higher)
 * Composer
 * Node.js & npm
 * SQLite for local, PostgreSQL for production


### PR DESCRIPTION
Добавила необходимую версию PHP.

За время установки SICP возникло несколько вопросов/замечаний:

1. `php artisan migrate --seed` нужен перед стартом проекта, его может стоит переместить выше в  README или в `make setup`.

2. для работы проекта потребовались команды : 

    `
sudo apt install php7.3-cli php7.3-fpm php7.3-json php7.3-mysql php7.3-zip php7.3-gd  php7.3-mbstring php7.3-curl php7.3-xml php7.3-bcmath
 `
(утащила с сайта, не знаю что из этого действительно было нужно)

    `sudo apt-get install php7.3-sqlite3`

    Как это лучше и правильнее оформить в Requirements

3. Сергей предлагал что-то из этого добавить в  composer.json