### PR TITLE
Fix welcome layout

### DIFF
--- a/resources/sass/_activity_chart.scss
+++ b/resources/sass/_activity_chart.scss
@@ -8,11 +8,6 @@
     --week-width: calc(var(--square-size) + var(--square-gap));
 }
 
-.graph {
-    display: inline-grid;
-    grid-template-columns: auto 1fr;
-    grid-gap: 10px;
-}
 .squares {
     display: grid;
     grid-gap: var(--square-gap);
@@ -20,13 +15,10 @@
     grid-auto-flow: column;
     grid-auto-columns: var(--square-size);
     padding: 0;
-    grid-area: squares;
 }
 
 .graph {
-    padding: 20px;
     border: 1px #e1e4e8 solid;
-    margin: 20px;
 }
 
 .squares li {

--- a/resources/views/components/activity_chart.blade.php
+++ b/resources/views/components/activity_chart.blade.php
@@ -1,7 +1,9 @@
 <div class="graph mt-5">
-    <ul class="squares">
-    @foreach($chart as $square)
-        <li data-level="{{ $square }}"></li>
-    @endforeach
-    </ul>
+    <div class="d-flex align-items-end flex-column overflow-hidden m-4">
+        <ul class="squares mb-0">
+            @foreach($chart as $square)
+                <li data-level="{{ $square }}"></li>
+            @endforeach
+        </ul>
+    </div>
 </div>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -10,7 +10,38 @@
         <a href="https://mitpress.mit.edu/sites/default/files/sicp/index.html">
             <img class="img-fluid" src="{{ asset('img/Patchouli_Gives_SICP.png') }}" alt="Начать изучать sicp">
         </a>
+    </div>
+    <div class="col-md-4">
+        <h2 class="my-3">{{ __('welcome.what_is_here') }}</h2>
+        <p>{{ __('welcome.about_sicp') }}
+            <br>
+            <a href="https://guides.hexlet.io/how-to-learn-sicp/">{{ __('layout.nav.sicp_read') }}</a>
+        </p>
+        <h2 class="my-3">{{ __('welcome.features') }}</h2>
+        <ul>
+            @foreach (__('welcome.features_list') as $key => $item)
+            <li>{{ __(sprintf('welcome.features_list.%s', $key)) }}</li>
+            @endforeach
+        </ul>
+        <h2 class="my-3">{{ __('welcome.coming_soon') }}</h2>
+        <ul>
+            @foreach (__('welcome.coming_soon_list') as $key => $item)
+            <li>{{ __(sprintf('welcome.coming_soon_list.%s', $key)) }}</li>
+            @endforeach
+
+        </ul>
+        <a class="btn btn-primary" href="{{ (route('my')) }}" role="button">{{ __('layout.welcome.mark_read') }}</a>
+    </div>
+</div>
+
+<div class="row">
+    <div class="col-md-12">
         @include('components.activity_chart')
+    </div>
+</div>
+
+<div class="row">
+    <div class="col-md-8">
         <h3 class="my-3"><a href="{{ (route('log.index')) }}">{{ __('activitylog.title') }}</a></h3>
         @foreach($logItems as $logItem)
         <div class="media text-muted pt-1">
@@ -65,27 +96,7 @@
         </div>
         @endforeach
     </div>
-    <div class="col-md-4">
-        <h2 class="my-3">{{ __('welcome.what_is_here') }}</h2>
-        <p>{{ __('welcome.about_sicp') }}
-            <br>
-            <a href="https://guides.hexlet.io/how-to-learn-sicp/">{{ __('layout.nav.sicp_read') }}</a>
-        </p>
-        <h2 class="my-3">{{ __('welcome.features') }}</h2>
-        <ul>
-            @foreach (__('welcome.features_list') as $key => $item)
-            <li>{{ __(sprintf('welcome.features_list.%s', $key)) }}</li>
-            @endforeach
-        </ul>
-        <h2 class="my-3">{{ __('welcome.coming_soon') }}</h2>
-        <ul>
-            @foreach (__('welcome.coming_soon_list') as $key => $item)
-            <li>{{ __(sprintf('welcome.coming_soon_list.%s', $key)) }}</li>
-            @endforeach
-
-        </ul>
-        <a class="btn btn-primary" href="{{ (route('my')) }}" role="button">{{ __('layout.welcome.mark_read') }}</a>
-    </div>
 </div>
+
 <!-- /.row -->
 @endsection


### PR DESCRIPTION
На главной странице немного неправильно была выстроена вёрстка, поэтому вступительный текст заезжал на график активностей.
Изменения небольшие, просто перемещение блоков, поэтому тут же добавлена адаптивность графика. Теперь при уменьшении окна браузера начало графика скрывается.

Исправляет #214 

[Демо на heroku](https://tranquil-inlet-51072.herokuapp.com/).
