### PR TITLE
Navbar fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4670,9 +4670,9 @@
             "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
         },
         "jquery": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.0.tgz",
-            "integrity": "sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ=="
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+            "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
         },
         "jquery-ujs": {
             "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "axios": "^0.18",
     "bootstrap": "^4.4.1",
     "cross-env": "^5.1",
-    "jquery": "^3.5",
+    "jquery": "^3.4.1",
     "jquery-ujs": "^1.2.2",
     "laravel-mix": "^4.0.7",
     "lodash": "^4.17.5",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "axios": "^0.18",
     "bootstrap": "^4.4.1",
     "cross-env": "^5.1",
-    "jquery": "3.4.1",
+    "jquery": "^3.4.1",
     "jquery-ujs": "^1.2.2",
     "laravel-mix": "^4.0.7",
     "lodash": "^4.17.5",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "axios": "^0.18",
     "bootstrap": "^4.4.1",
     "cross-env": "^5.1",
-    "jquery": "^3.4.1",
+    "jquery": "3.4.1",
     "jquery-ujs": "^1.2.2",
     "laravel-mix": "^4.0.7",
     "lodash": "^4.17.5",


### PR DESCRIPTION
Версия jquery 3.5 не совсем подходит для бутсрапа.
https://sicp.hexlet.io -> навбар не расширяется при маленьком экране, на телефоне и на компе.
https://sicp-demo.herokuapp.com -> здесь поставил 3.4.1, навбар раскрывается правильно и на компе и на телефоне.