### PR TITLE
fix exercise list syntax. add title exercise

### DIFF
--- a/resources/views/exercise/index.blade.php
+++ b/resources/views/exercise/index.blade.php
@@ -15,8 +15,8 @@
         <div class="col-12 col-md-4 mb-2">
             <ul class="nav nav-pills flex-column sticky-top x-z-index-0" role="tablist">
                 @foreach($exercisesGroups->keys() as $rootChapterPath)
-                    <li>
-                        <a class="nav-item nav-link {{ $rootChapterPath === 1 ? 'active' : '' }}"
+                    <li class="nav-item">
+                        <a class="nav-link {{ $rootChapterPath === 1 ? 'active' : '' }}"
                             id="subChapters{{ $rootChapterPath }}-tab"
                             href="#subChapters{{ $rootChapterPath }}" data-toggle="tab" role="tab"
                             aria-controls="subChapters{{ $rootChapterPath }}"
@@ -31,7 +31,7 @@
             <div class="card pl-2 pr-3">
                 <div class="tab-content">
                 @foreach($exercisesGroups as $rootChapterPath => $exercises)
-                    <div list-style="none" class="tab-pane card-body {{ $rootChapterPath === 1 ? 'active' : '' }}"
+                    <div class="tab-pane card-body {{ $rootChapterPath === 1 ? 'active' : '' }}"
                         id="subChapters{{ $rootChapterPath }}" role="tabpanel"
                         aria-labelledby="subChapters{{ $rootChapterPath }}-tab">
                         <ul class="list-unstyled">

--- a/resources/views/exercise/index.blade.php
+++ b/resources/views/exercise/index.blade.php
@@ -13,34 +13,37 @@
     </div>
     <div class="row mt-2">
         <div class="col-12 col-md-4 mb-2">
-            <div class="nav nav-pills flex-column sticky-top x-z-index-0" role="tablist">
+            <ul class="nav nav-pills flex-column sticky-top x-z-index-0" role="tablist">
                 @foreach($exercisesGroups->keys() as $rootChapterPath)
-                    <a class="nav-item nav-link {{ $rootChapterPath === 1 ? 'active' : '' }}"
-                       id="subChapters{{ $rootChapterPath }}-tab"
-                       href="#subChapters{{ $rootChapterPath }}" data-toggle="tab" role="tab"
-                       aria-controls="subChapters{{ $rootChapterPath }}"
-                       aria-selected="{{ $rootChapterPath === '1' ? 'true' : 'false' }}">
-                    {{$rootChapterPath}}. {{ getChapterName($rootChapterPath)  }}
-                    </a>
+                    <li>
+                        <a class="nav-item nav-link {{ $rootChapterPath === 1 ? 'active' : '' }}"
+                            id="subChapters{{ $rootChapterPath }}-tab"
+                            href="#subChapters{{ $rootChapterPath }}" data-toggle="tab" role="tab"
+                            aria-controls="subChapters{{ $rootChapterPath }}"
+                            aria-selected="{{ $rootChapterPath === '1' ? 'true' : 'false' }}">
+                            {{ $rootChapterPath }}. {{ getChapterName($rootChapterPath) }}
+                        </a>
+                    </li>
                 @endforeach
-            </div>
+            </ul>
         </div>
         <div class="col-12 col-md-8">
             <div class="card pl-2 pr-3">
                 <div class="tab-content">
                 @foreach($exercisesGroups as $rootChapterPath => $exercises)
-                    <div class="tab-pane card-body {{ $rootChapterPath === 1 ? 'active' : '' }}"
-                         id="subChapters{{ $rootChapterPath }}" role="tabpanel"
-                         aria-labelledby="subChapters{{ $rootChapterPath }}-tab">
-                        <p>
-                            @foreach($exercises as $exercise)
-                            <a title="{{ __('exercise.exercise') }} {{ $exercise->path }}"
-                               href="{{ route('exercises.show', $exercise) }}">
-                                {{ $exercise->path }} {{ getExerciseTitle($exercise) }}
-                                <br>
-                            </a>
-                            @endforeach
-                        </p>
+                    <div list-style="none" class="tab-pane card-body {{ $rootChapterPath === 1 ? 'active' : '' }}"
+                        id="subChapters{{ $rootChapterPath }}" role="tabpanel"
+                        aria-labelledby="subChapters{{ $rootChapterPath }}-tab">
+                        <ul class="list-unstyled">
+                        @foreach($exercises as $exercise)
+                            <li>
+                                <a title="{{ __('exercise.exercise') }} {{ $exercise->path }}"
+                                    href="{{ route('exercises.show', $exercise) }}">
+                                    {{ $exercise->path }} {{ getExerciseTitle($exercise) }}
+                                </a>
+                            </li>
+                        @endforeach
+                    </ul>
                     </div>
                 @endforeach
                 </div>

--- a/resources/views/exercise/show.blade.php
+++ b/resources/views/exercise/show.blade.php
@@ -92,8 +92,7 @@
             <hr>
             <p>{{ __('exercise.show.nobody_completed') }}</p>
             @else
-            <br>
-            <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#modalCart">{{ __('exercise.show.who_completed') }}</button>
+            <button type="button" class="btn btn-primary mt-4" data-toggle="modal" data-target="#modalCart">{{ __('exercise.show.who_completed') }}</button>
             <div class="modal fade" id="modalCart" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
                 <div class="modal-dialog" role="document">
                     <div class="modal-content">

--- a/resources/views/exercise/show.blade.php
+++ b/resources/views/exercise/show.blade.php
@@ -37,7 +37,8 @@
                 </a>
                 @endif
             </small>
-            <h1>
+            
+            <div class="h4 mt-2">
                 {{ __('exercise.exercise') }} {{ $exercise->path }}
                 <small>
                     <a class="text-muted"
@@ -49,7 +50,8 @@
                         <i class="fas fa-external-link-alt"></i>
                     </a>
                 </small>
-            </h1>
+            </div>
+            <h1 class="mb-2">{{ getExerciseTitle($exercise) }}</h1>
             <div>
                 @if(view()->exists(getExerciseListingViewFilepath($exercise->path)))
                 @include(getExerciseListingViewFilepath($exercise->path))
@@ -87,6 +89,7 @@
             {!! Form::close() !!}
             @endauth
             @if($exercise->users->isEmpty())
+            <hr>
             <p>{{ __('exercise.show.nobody_completed') }}</p>
             @else
             <br>
@@ -114,6 +117,7 @@
                 </div>
             </div>
             @endif
+            <hr>
             @comments(['model' => $exercise])
         </div>
     </div>


### PR DESCRIPTION
Попытался пофиксить вывод 
1. использовать синтаксис вывода списка, убрать ```<br>```;
https://hexlet-sicp-test.herokuapp.com/exercises
было
![Снимок экрана 2020-06-15 в 15 56 53](https://user-images.githubusercontent.com/11249101/84660202-2a7f7880-af21-11ea-8896-973868f2967d.png)
стало
![Снимок экрана 2020-06-15 в 15 55 40](https://user-images.githubusercontent.com/11249101/84660222-323f1d00-af21-11ea-88f5-03ed2030a671.png)

2. в карточке упражнения - вывел названия и отбил комментарии и текст "Это упражнение еще никто не завершил. Ты будешь первым!"
https://hexlet-sicp-test.herokuapp.com/exercises/49
было
![Снимок экрана 2020-06-15 в 16 01 24](https://user-images.githubusercontent.com/11249101/84660879-2d2e9d80-af22-11ea-8ade-1c1a6e64dc73.png)
стало
![Снимок экрана 2020-06-15 в 16 02 07](https://user-images.githubusercontent.com/11249101/84660899-33bd1500-af22-11ea-980b-f2b077833f40.png)
и
![Снимок экрана 2020-06-15 в 16 05 54](https://user-images.githubusercontent.com/11249101/84660916-39b2f600-af22-11ea-9a59-dc2b9ee4b67e.png)

