### PR TITLE
fix redirect for unauthorized users

### DIFF
--- a/app/Http/Controllers/Settings/ProfileController.php
+++ b/app/Http/Controllers/Settings/ProfileController.php
@@ -8,6 +8,11 @@ use Auth;
 
 class ProfileController extends Controller
 {
+    public function __construct()
+    {
+        $this->middleware('auth');
+    }
+
     public function index()
     {
         $user = auth()->user();


### PR DESCRIPTION
Поправил 500 ошибку для неавторизованных пользователей.
На settings/profile
Было 
![Screenshot from 2020-06-19 00-37-59](https://user-images.githubusercontent.com/51837177/85074488-4acf6180-b1c5-11ea-85eb-c63d21b12a1f.png)

Теперь редиректит на /login
