### PR TITLE
[#884-bugfix] fix active nav bars bg-color

### DIFF
--- a/resources/js/components/style.css
+++ b/resources/js/components/style.css
@@ -3,8 +3,8 @@
   /* background-color: rgb(164, 216, 143); */
 }
 
-.nav-link.active {
-  background-color: #f5f7fb!important;
+#codemirrorContainer .nav-link.active {
+  background-color: #f5f7fb;
 };
 
 #codemirrorContainer {


### PR DESCRIPTION
#884 поправил селектор так, чтобы стили из тестового кодмиррор не перекрывали прод.

![Снимок экрана от 2021-06-23 10-30-11](https://user-images.githubusercontent.com/69354716/123032118-a1423200-d40f-11eb-9666-88aeb38f32d6.png)
