### PR TITLE
remove index.php from url

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -4,6 +4,7 @@ namespace App\Providers;
 
 use Illuminate\Support\Facades\Route;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+use Illuminate\Support\Str;
 
 class RouteServiceProvider extends ServiceProvider
 {
@@ -36,10 +37,30 @@ class RouteServiceProvider extends ServiceProvider
      */
     public function map(): void
     {
+        $this->removeIndexPhpFromUrl();
+
         $this->mapApiRoutes();
 
         $this->mapWebRoutes();
     }
+
+    /**
+     * Remove index.php from url.
+     *
+     */
+
+    protected function removeIndexPhpFromUrl()
+    {
+        if (Str::contains(request()->getRequestUri(), '/index.php/')) {
+            $url = str_replace('index.php/', '', request()->getRequestUri());
+
+            if (strlen($url) > 0) {
+                header("Location: $url", true, 301);
+                exit;
+            }
+        }
+    }
+
 
     /**
      * Define the "web" routes for the application.

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -48,7 +48,6 @@ class RouteServiceProvider extends ServiceProvider
      * Remove index.php from url.
      *
      */
-
     protected function removeIndexPhpFromUrl()
     {
         if (Str::contains(request()->getRequestUri(), '/index.php/')) {
@@ -60,7 +59,6 @@ class RouteServiceProvider extends ServiceProvider
             }
         }
     }
-
 
     /**
      * Define the "web" routes for the application.


### PR DESCRIPTION
It removes index.php or public/index.php from the generated URL.
Commonly path is https://sicp.hexlet.io/index.php/ru/exercises.
It should be something like https://sicp.hexlet.io/ru/exercises.