### PR TITLE
forgot to fix test after fixing the exercise

### DIFF
--- a/resources/views/exercise/solution_stub/1_11.blade.php
+++ b/resources/views/exercise/solution_stub/1_11.blade.php
@@ -5,7 +5,7 @@
 {!! $solution !!}
 ;;; END
 
-(check-equal? (f 5) 11)
-(check-equal? (f-iter 5) 11)
-(check-equal? (f 3) 3)
+(check-equal? (f 4) 11)
+(check-equal? (f-iter 4) 11)
+(check-equal? (f 3) 4)
 (check-equal? (f-iter 1) 1)

--- a/resources/views/exercise/solution_stub/1_11_solution.blade.php
+++ b/resources/views/exercise/solution_stub/1_11_solution.blade.php
@@ -1,13 +1,13 @@
 (define (f x)
   (if (< x 3)
       x
-      (+ (f (- x 1)) (f (- x 2)) (f (- x 3)))))
+      (+ (f (- x 1)) (* 2 (f (- x 2))) (* 3 (f (- x 3))))))
 
 (define (f-iter x)
   (define (iter-step a b c count)
     (if (= count 0)
         c
-        (iter-step (+ a b c) a b (- count 1))))
+        (iter-step (+ a (* 2 b) (* 3 c)) a b (- count 1))))
   (if (< x 3)
       x
       (iter-step 2 1 0 x)))


### PR DESCRIPTION
В русском издании книги была некорректная формула в упражнении 1.11
f(n) = f(n−1) + f(n−2) + f(n−3) вместо f(n) = f(n - 1) + 2f(n - 2) + 3f(n - 3)
Формулу поправили, а тесты упустили. Подробнее здесь - https://sicp.hexlet.io/ru/exercises/11#exercise-discussion