### PR TITLE
[fix] Поправлена верстка кнопки закрытия модального окна

### DIFF
--- a/resources/views/chapter/show.blade.php
+++ b/resources/views/chapter/show.blade.php
@@ -100,9 +100,7 @@
                             <div class="modal-content">
                                 <div class="modal-header">
                                     <h4 class="modal-title" id="completed-by-modal-title">{{ __('chapter.show.completed_by') }}</h4>
-                                    <button type="button" class="close" data-bs-dismiss="modal" aria-label="{{ __('layout.common.close') }}">
-                                        <span aria-hidden="true">×</span>
-                                    </button>
+                                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ __('layout.common.close') }}"></button>
                                 </div>
                                 <div class="modal-body">
                                     <ul>

--- a/resources/views/components/comment/_modal.blade.php
+++ b/resources/views/components/comment/_modal.blade.php
@@ -13,9 +13,7 @@
             {{ BsForm::open(route('comments.update', ['comment' => $comment]), ['method' => $method]) }}
             <div class="modal-header">
                 <h5 class="modal-title">{{ __($modalTitle) }}</h5>
-                <button type="button" class="close" data-bs-dismiss="modal">
-                    <span>&times;</span>
-                </button>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
             </div>
             <div class="modal-body">
                 {{ Form::hidden('commentable_type', $comment->commentable_type) }}

--- a/resources/views/components/comment/reply/_modal.blade.php
+++ b/resources/views/components/comment/reply/_modal.blade.php
@@ -4,9 +4,7 @@
             {{ BsForm::open(route('comments.store')) }}
             <div class="modal-header">
                 <h5 class="modal-title">{{ __('comment.reply_to_comment') }}</h5>
-                <button type="button" class="close" data-bs-dismiss="modal">
-                    <span>&times;</span>
-                </button>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
             </div>
             <div class="modal-body">
                 {{ Form::hidden('commentable_type', $comment->commentable_type) }}

--- a/resources/views/exercise/_modal/completed_by.blade.php
+++ b/resources/views/exercise/_modal/completed_by.blade.php
@@ -5,9 +5,7 @@
             <div class="modal-header">
                 <h4 class="modal-title"
                     id="completed-by-title">{{ __('exercise.show.completed_by') }}</h4>
-                <button type="button" class="close" data-bs-dismiss="modal" aria-label="{{ __('layout.common.close') }}">
-                    <span aria-hidden="true">×</span>
-                </button>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ __('layout.common.close') }}"></button>
             </div>
             <div class="modal-body">
                 <ul>

--- a/resources/views/vendor/flash/message.blade.php
+++ b/resources/views/vendor/flash/message.blade.php
@@ -13,9 +13,7 @@
         >
             {!! $message['message'] !!}
             @if($message['important'])
-                <button type="button" class="close" data-bs-dismiss="alert" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
-                </button>
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
             @endif
         </div>
     @endif

--- a/resources/views/vendor/flash/modal.blade.php
+++ b/resources/views/vendor/flash/modal.blade.php
@@ -2,7 +2,7 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-bs-dismiss="modal" aria-hidden="true">&times;</button>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-hidden="true"></button>
 
                 <h4 class="modal-title">{{ $title }}</h4>
             </div>


### PR DESCRIPTION
* Изменен класс `close` на `btn-close` у закрывающих кнопок
* Убран контент у кнопок. В Bootstrap 5 контент прописан в классе css

Скриншот с исправленной модалкой:
![image](https://user-images.githubusercontent.com/43718236/176023841-9741c108-f0b9-4af0-bd00-afb8116d40cd.png)
