### PR TITLE
fix: remove extra space in editor

### DIFF
--- a/resources/js/common/codeTemplates.js
+++ b/resources/js/common/codeTemplates.js
@@ -1,4 +1,4 @@
 export default {
-  withoutTemplate: (text) => `#| ${text} |#`,
-  withTemplate: (text, code) => `#| BEGIN (${text}) |#\n  ${code}\n#| END |#`,
+  withoutTemplate: (text) => `#| ${text} |#\n`,
+  withTemplate: (text, code) => `#| BEGIN (${text}) |#\n${code}\n#| END |#`,
 };


### PR DESCRIPTION
- [x] #1359

Нашел `codeTemplates` и сделал два действия:
1. Убрал лишние два пробела, как и просили в issue.
2. Добавил перенос строки для тех упражнений, где не требуется проверка, к примеру [Упражнение 1.1.](https://sicp.hexlet.io/ru/exercises/1)
  До этого приходилось: `перенос строки -> пишу код`
  Теперь: `просто пишу код`