### PR TITLE
Remove fontawesome dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "hexlet-sicp",
       "version": "1.0.0",
       "dependencies": {
-        "@fortawesome/fontawesome-free": "^5.15.4",
         "@popperjs/core": "^2.11.5",
         "@reduxjs/toolkit": "^1.6.2",
         "axios": "^0.25",
@@ -1736,14 +1735,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@fortawesome/fontawesome-free": {
-      "version": "5.15.4",
-      "hasInstallScript": true,
-      "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -12175,9 +12166,6 @@
           "dev": true
         }
       }
-    },
-    "@fortawesome/fontawesome-free": {
-      "version": "5.15.4"
     },
     "@humanwhocodes/config-array": {
       "version": "0.9.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "lint-js-fix": "node_modules/.bin/eslint --fix --ext .jsx,.js ./resources/js"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-free": "^5.15.4",
     "@popperjs/core": "^2.11.5",
     "@reduxjs/toolkit": "^1.6.2",
     "axios": "^0.25",

--- a/resources/js/components/Editor.jsx
+++ b/resources/js/components/Editor.jsx
@@ -61,7 +61,7 @@ const Editor = () => {
     ? (
       <div className="d-flex h-100 justify-content-center align-items-center">
         <Spinner animation="border" role="status" variant="primary">
-          <span className="sr-only">{t('loading')}</span>
+          <span className="visually-hidden">{t('loading')}</span>
         </Spinner>
       </div>
     )

--- a/resources/js/font-awesome.js
+++ b/resources/js/font-awesome.js
@@ -1,4 +1,0 @@
-import '@fortawesome/fontawesome-free/js/fontawesome';
-import '@fortawesome/fontawesome-free/js/solid';
-import '@fortawesome/fontawesome-free/js/regular';
-import '@fortawesome/fontawesome-free/js/brands';

--- a/resources/sass/_icons.scss
+++ b/resources/sass/_icons.scss
@@ -1,0 +1,11 @@
+.icon-lg {
+    font-size: 1.5rem;
+}
+
+.icon-4x {
+    font-size: 4rem;
+}
+
+.icon-2x {
+    font-size: 2rem;
+}

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -23,6 +23,8 @@
 
 @import "custom";
 
+@import "icons";
+
 // NOTE: move if it will be necessary. It should be do for the site.
 // TODO grep and replace by .bd-gray-200
 // https://getbootstrap.com/docs/5.0/customize/color/

--- a/resources/views/chapter/list.blade.php
+++ b/resources/views/chapter/list.blade.php
@@ -24,7 +24,7 @@
         <ul class="collapse list-unstyled" id="collapse{{ $chapter->id }}">
             @foreach($chapter->exercises as $exercise)
             <li>
-                <i class="bi bi-keyboard-fill fa-lg"></i>
+                <i class="bi bi-keyboard-fill icon-lg"></i>
                 <a href="{{ route('exercises.show', [$exercise]) }}">
                     {{ getFullExerciseTitle($exercise) }}
                 </a>

--- a/resources/views/components/sorting_widget.blade.php
+++ b/resources/views/components/sorting_widget.blade.php
@@ -2,10 +2,10 @@
     {{ $name }}
     @switch($sortParams)
         @case("-{$nameParams}")
-        <i class="fa fa-angle-up" aria-hidden="true"></i>
+        <i class="bi bi-chevron-up" aria-hidden="true"></i>
         @break
         @case($nameParams)
-        <i class="fa fa-angle-down" aria-hidden="true"></i>
+        <i class="bi bi-chevron-down" aria-hidden="true"></i>
         @break
         @default
     @endswitch

--- a/resources/views/home/landing.blade.php
+++ b/resources/views/home/landing.blade.php
@@ -35,11 +35,11 @@
         </div>
         <a class="carousel-control-prev" href="#sicpCarousel" role="button" data-bs-slide="prev">
             <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-            <span class="sr-only">{{ __('pagination.previous') }}</span>
+            <span class="visually-hidden">{{ __('pagination.previous') }}</span>
         </a>
         <a class="carousel-control-next" href="#sicpCarousel" role="button" data-bs-slide="next">
             <span class="carousel-control-next-icon" aria-hidden="true"></span>
-            <span class="sr-only">{{ __('pagination.next') }}</span>
+            <span class="visually-hidden">{{ __('pagination.next') }}</span>
         </a>
     </div>
     <div class="row">
@@ -99,19 +99,19 @@
     <hr class="mt-5 mb-5">
     <div class="row mb-4">
         <div class="col-lg-3 text-center">
-            <i class="bi bi-book-fill fa-4x"></i>
+            <i class="bi bi-book-fill icon-4x"></i>
             <h2>{{ __('landing.actions_list.1') }}</h2>
         </div>
         <div class="col-lg-3 text-center">
-            <i class="bi bi-code-square fa-4x"></i>
+            <i class="bi bi-code-square icon-4x"></i>
             <h2>{{ __('landing.actions_list.2') }}</h2>
         </div>
         <div class="col-lg-3 text-center">
-            <i class="bi bi-pen-fill fa-4x"></i>
+            <i class="bi bi-pen-fill icon-4x"></i>
             <h2>{{ __('landing.actions_list.3') }}</h2>
         </div>
         <div class="col-lg-3 text-center">
-            <i class="bi bi-award fa-4x"></i>
+            <i class="bi bi-award icon-4x"></i>
             <h2>{{ __('landing.actions_list.4') }}</h2>
         </div>
     </div>

--- a/resources/views/layouts/_nav.blade.php
+++ b/resources/views/layouts/_nav.blade.php
@@ -68,7 +68,7 @@
                         aria-expanded="false"
                         href="#"
                     >
-                        <i class="bi bi-person fa-lg"></i>
+                        <i class="bi bi-person icon-lg"></i>
                     </a>
                     <ul
                         class="dropdown-menu x-z-index-dropdown dropdown-menu-right"

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -116,7 +116,6 @@
     @livewireScripts
     <script src="{{ mix('js/app.js') }}" defer></script>
     <script src="{{ mix('js/hljs.js')}}"></script>
-    <script src="{{ mix('js/font-awesome.js') }}" defer></script>
     @stack('scripts')
 </body>
 </html>

--- a/resources/views/user/show.blade.php
+++ b/resources/views/user/show.blade.php
@@ -42,7 +42,7 @@
                     @if ($user->github_name)
                     <span>
                         <a class="x-link-without-decoration mr-3 mb-2 text-dark" target="_blank" rel="noopener noreferrer" href="https://github.com/{{ $user->github_name }}">
-                            <i class="bi bi-github fa-2x"></i>
+                            <i class="bi bi-github icon-2x"></i>
                         </a>
                     </span>
                     @endif

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -14,7 +14,6 @@ const mix = require('laravel-mix');
 mix
   .version()
   .js('resources/js/app.js', 'public/js')
-  .js('resources/js/font-awesome.js', 'public/js')
   .js('resources/js/hljs.js', 'public/js/hljs.js')
   .js('resources/js/editor.js', 'public/js')
   .react()


### PR DESCRIPTION
Fixes: #964 

- Removed  `@fortawesome/fontawesome-free` dependency
- Added icons styles for setting up icon size. Size like the prefered way to set up icons sizes is via `font-size` property https://icons.getbootstrap.com/#usage
- Replaced sr-only class based on https://getbootstrap.com/docs/5.2/getting-started/accessibility/#visually-hidden recommendations
- `fa-icons` replaced in favor on `bi`
