### PR TITLE
improve solutions check

### DIFF
--- a/.github/workflows/solutions.yml
+++ b/.github/workflows/solutions.yml
@@ -1,0 +1,24 @@
+name: CI status
+
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: satackey/action-docker-layer-caching@v0.0.11
+
+      - name: Run CI
+        run: |
+          make ci
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          file: build/logs/clover.xml
+        # fail_ci_if_error: true

--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,10 @@ lint-fix:
 	composer exec phpcbf -v
 
 test:
-	php artisan test
+	php artisan test --testsuite "Feature"
 
 test-solutions:
-	php artisan test --testsuite "Exercises"
+	composer exec phpunit -- --testsuite "Exercises"
 
 test-coverage:
 	XDEBUG_MODE=coverage php artisan test --coverage-clover build/logs/clover.xml

--- a/composer.json
+++ b/composer.json
@@ -94,6 +94,10 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "scripts": {
+        "test-solutions": [
+            "Composer\\Config::disableProcessTimeout",
+            "phpunit --testsuite Exercises"
+        ],
         "post-autoload-dump": [
             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
             "@php artisan package:discover --ansi"

--- a/config/logging.php
+++ b/config/logging.php
@@ -97,5 +97,5 @@ return [
         ],
     ],
 
-    'log_sql_queries' => ENV('LOG_SQL_QUERIES', false),
+    'log_sql_queries' => true,
 ];

--- a/make-compose.mk
+++ b/make-compose.mk
@@ -66,6 +66,11 @@ compose-check:
 
 ci:
 	docker-compose -f docker-compose.ci.yml -p hexlet-sicp-ci build ${BUILD_ARGS}
-	docker-compose -f docker-compose.ci.yml -p hexlet-sicp-ci run application make setup
+	docker-compose -f docker-compose.ci.yml -p hexlet-sicp-ci run --rm application make setup
 	docker-compose -f docker-compose.ci.yml -p hexlet-sicp-ci up --abort-on-container-exit
+	docker-compose -f docker-compose.ci.yml -p hexlet-sicp-ci down -v --remove-orphans
+
+ci-solutions:
+	docker-compose -f docker-compose.ci.yml -p hexlet-sicp-ci build ${BUILD_ARGS}
+	docker-compose -f docker-compose.ci.yml -p hexlet-sicp-ci run --rm application make install-app test-solutions
 	docker-compose -f docker-compose.ci.yml -p hexlet-sicp-ci down -v --remove-orphans

--- a/tests/Exercises/TeacherSolutionsTest.php
+++ b/tests/Exercises/TeacherSolutionsTest.php
@@ -9,6 +9,7 @@ use App\Models\User;
 use Database\Seeders\ChaptersTableSeeder;
 use Database\Seeders\ExercisesTableSeeder;
 use Illuminate\Support\Collection;
+use Symfony\Component\Yaml\Yaml;
 
 class TeacherSolutionsTest extends TestCase
 {
@@ -21,34 +22,48 @@ class TeacherSolutionsTest extends TestCase
         parent::setUp();
         $this->seed(ChaptersTableSeeder::class);
         $this->seed(ExercisesTableSeeder::class);
-
         /** @var User $user */
         $user = User::factory()->create();
         $this->user = $user;
 
-        // NOTE: The Miller Rabin test is probabilistic and its result is non-deterministic
-        $millerRabinExercisePath = '1.28';
-        $this->exercises = Exercise::where('path', '!=', $millerRabinExercisePath)
-            ->orderBy('id')
-            ->get();
-
         $this->solutionChecker = new SolutionChecker();
     }
 
-    public function testTeacherSolutions(): void
+    public function dataProvider(): array
     {
-        foreach ($this->exercises as $exercise) {
-            if ($exercise->hasTeacherSolution()) {
-                $teacherSolution = $exercise->getExerciseTeacherSolution();
-                $checkResult = $this->solutionChecker->check($this->user, $exercise, $teacherSolution);
+        $fixturePath = implode('/', [__DIR__, '..', '..', 'database', 'exercises.yml']);
+        $exercisesByChapters =  collect(Yaml::parseFile($fixturePath));
 
-                $exerciseFullTitle = $exercise->getFullTitle();
-                $output = $checkResult->getOutput();
-                $this->assertTrue(
-                    $checkResult->isSuccess(),
-                    "Exercise \"{$exerciseFullTitle}\" has errors in solution:\n{$output}"
-                );
-            }
+        return $exercisesByChapters
+            ->pluck('children')
+            ->flatten()
+            ->map(fn($path) => [$path])
+            ->toArray();
+    }
+
+    /**
+     * @dataProvider dataProvider
+     */
+    public function testTeacherSolutions(string $exercisePath): void
+    {
+        $millerRabinExercisePath = '1.28';
+        if ($exercisePath === $millerRabinExercisePath) {
+            $this->markTestSkipped('The Miller Rabin test is probabilistic and its result is non-deterministic');
         }
+
+        $exercise = Exercise::wherePath($exercisePath)->firstOrFail();
+
+        if (!$exercise->hasTeacherSolution()) {
+            $this->markTestSkipped("Exercise {$exercisePath} doesnt have teacher solution");
+        }
+        $teacherSolution = $exercise->getExerciseTeacherSolution();
+        $checkResult = $this->solutionChecker->check($this->user, $exercise, $teacherSolution);
+
+        $exercisePath = $exercise->path;
+        $output = $checkResult->getOutput();
+        $this->assertTrue(
+            $checkResult->isSuccess(),
+            "Exercise \"{$exercisePath}\" has errors in solution:\n{$output}"
+        );
     }
 }


### PR DESCRIPTION
В текущем виде при запуске тестов запускались тесты на решение, при этом не было никакого фидбека от тестов, вывода и тд.

Более правильный путь сделать это через дата провайдер, чтобы каждое решение считалось своим тестом. Плюс ларавел коряво отображает такие тесты (выводит результат только выполнения всех тестов на тестовых данных), поэтому решил использовать напрямую phpunit.

ну и так как тесты долго работают, выделил в отдельную CI