### PR TITLE
[#1633] fix link to free webinars

### DIFF
--- a/resources/lang/ru/layout.php
+++ b/resources/lang/ru/layout.php
@@ -32,7 +32,7 @@ return [
         'volunteers_in_tg'  => 'Telegram',
         'other_os_projects' => 'OpenSource',
         'help'              => 'Помощь',
-        'free'              => 'Бесплатно',
+        'free'              => 'Учиться бесплатно',
         'blog'              => 'Блог',
         'recommended_books' => 'Рекомендуемые книги',
         'additionally'      => 'Дополнительно',

--- a/resources/lang/ru/layout.php
+++ b/resources/lang/ru/layout.php
@@ -32,7 +32,7 @@ return [
         'volunteers_in_tg'  => 'Telegram',
         'other_os_projects' => 'OpenSource',
         'help'              => 'Помощь',
-        'knowledge'         => 'База знаний',
+        'free'              => 'Бесплатно',
         'blog'              => 'Блог',
         'recommended_books' => 'Рекомендуемые книги',
         'additionally'      => 'Дополнительно',

--- a/resources/views/layouts/_footer.blade.php
+++ b/resources/views/layouts/_footer.blade.php
@@ -16,7 +16,7 @@
         <ul class="nav flex-column align-items-start">
           <li><a href="https://ru.hexlet.io/blog" class="nav-link px-0">{{ __('layout.footer.blog') }}</a>
           </li>
-          <li><a href="https://ru.hexlet.io/knowledge" class="nav-link px-0">{{ __('layout.footer.knowledge') }}</a>
+          <li><a href="https://ru.hexlet.io/webinars" class="nav-link px-0">{{ __('layout.footer.free') }}</a>
           </li>
           <li><a href="https://ru.hexlet.io/pages/recommended-books"
               class="nav-link px-0">{{ __('layout.footer.recommended_books') }}</a></li>


### PR DESCRIPTION
## Pull request details

Change in the footer: the "Knowledge Base" link https://ru.hexlet.io/knowledge, which redirected to https://ru.hexlet.io/webinars, has been replaced with a "Free" link that sends directly to https: //ru.hexlet.io/webinars.


## Issues fixed

issue #1633

