### PR TITLE
Fixed bug: the 'Enter your message here (markdown supported)' placeho…

### DIFF
--- a/resources/views/components/comment/_comment.blade.php
+++ b/resources/views/components/comment/_comment.blade.php
@@ -62,7 +62,7 @@
             {{ html()->hidden('commentable_id') }}
             <div class="form-floating">
               {{ html()->textarea('content')->class('form-control h-100')->required() }}
-              <label for="content" class="w-100">{{ __('comment.enter_your_message') }}</label>
+              <label for="content" class="w-100 text-wrap">{{ __('comment.enter_your_message') }}</label>
             </div>
           </div>
           <div class="modal-footer text-left">

--- a/resources/views/components/comment/_form.blade.php
+++ b/resources/views/components/comment/_form.blade.php
@@ -10,7 +10,7 @@
     {{ html()->hidden('commentable_id')->value($model->id) }}
     <div class="form-floating">
       {{ html()->textarea('content')->class('form-control x-min-h-100px')->required() }}
-      <label for="content" class="w-100">{{ __('comment.enter_your_message') }}</label>
+      <label for="content" class="w-100 text-wrap">{{ __('comment.enter_your_message') }}</label>
     </div>
     <div class="mt-3">
           {{ html()->submit(__('comment.submit'))->class('btn btn-success btn-sm text-uppercase') }}

--- a/resources/views/components/comment/reply/_modal.blade.php
+++ b/resources/views/components/comment/reply/_modal.blade.php
@@ -12,7 +12,7 @@
         {{ html() ->hidden('parent_id')->value($comment->id) }}
         <div class="form-floating">
           {{ html()->textarea('content')->class('form-control h-100')->required() }}
-          <label for="content" class="w-100">{{ __('comment.enter_your_message') }}</label>
+          <label for="content" class="w-100 text-wrap">{{ __('comment.enter_your_message') }}</label>
         </div>
       </div>
       <div class="modal-footer text-left">


### PR DESCRIPTION
Issues fixed #1630

Fixed a bug: the “Enter your message here (markdown supported)” placeholder was going outside the div container boundaries. 

Enabled text wrap for label in CSS