### PR TITLE
Fix: Исправлен заголовок модального окна в форме редактирования комментария

### DIFF
--- a/resources/views/components/comment/_comment.blade.php
+++ b/resources/views/components/comment/_comment.blade.php
@@ -55,7 +55,7 @@
           <div class="modal-content">
             {{ html()->modelForm($comment, 'PUT', route('comments.update', ['comment' => $comment]))->open() }}
             <div class="modal-header">
-              <h5 class="modal-title">{{ __('comment.edit_comment') }}/h5>
+              <h5 class="modal-title">{{ __('comment.edit_comment') }}</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
             </div>
             <div class="modal-body">


### PR DESCRIPTION
## Pull request details

Исправлена ошибка в отображении заголовка модального окна при редактировании комментария. Теперь он должен отображатся корректно.

## Issues fixed
[issue #1685](https://github.com/Hexlet/hexlet-sicp/issues/1685)

