### PR TITLE
Delete link hexlet guides

### DIFF
--- a/resources/lang/en/layout.php
+++ b/resources/lang/en/layout.php
@@ -43,7 +43,6 @@ return [
             'friends' => 'Hexlet Friends',
             'code_basics' => 'Code Basics',
             'codebattle' => 'CodeBattle',
-            'guides' => 'Hexlet Guides',
             'hexlet' => 'Hexlet',
         ],
     ],

--- a/resources/lang/ru/layout.php
+++ b/resources/lang/ru/layout.php
@@ -41,7 +41,6 @@ return [
             'friends' => 'Друзья Хекслета',
             'code_basics' => 'Code Basics',
             'codebattle' => 'Кодбаттл',
-            'guides' => 'Гайды Хекслета',
             'hexlet' => 'Хекслет',
         ],
     ],

--- a/resources/views/layouts/_footer.blade.php
+++ b/resources/views/layouts/_footer.blade.php
@@ -41,8 +41,6 @@
               href="https://ru.code-basics.com/">{{ __('layout.footer.os_projects.code_basics') }}</a></li>
           <li><a class="nav-link px-0"
               href="https://codebattle.hexlet.io/">{{ __('layout.footer.os_projects.codebattle') }}</a></li>
-          <li><a class="nav-link px-0"
-              href="https://guides.hexlet.io/">{{ __('layout.footer.os_projects.guides') }}</a></li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
The footer link to the hexlet guides resource has also been removed. Resources for languages ​​have been cleaned up.

demo -->  https://hexlet-sicp-ly1k.onrender.com/ru