### PR TITLE
updated xdebug.ini and Dockerfile.dev to enable xdebug

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -44,6 +44,6 @@ RUN curl -sL https://deb.nodesource.com/setup_${NODE_MAJOR}.x | bash -
 RUN apt-get install -y nodejs
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-COPY ./xdebug.ini /etc/php/${PHP_VERSION}/conf.d/docker-php-ext-xdebug.ini
+COPY ./xdebug.ini /etc/php/${PHP_VERSION}/cli/conf.d/99-xdebug-custom.ini
 
 ENV PATH=/app/node_modules/.bin/:${PATH}

--- a/xdebug.ini
+++ b/xdebug.ini
@@ -1,6 +1,6 @@
-zend_extension=xdebug
-
 error_reporting=E_ALL
+
 [xdebug]
-xdebug.mode=develop
+xdebug.mode=develop,debug
 xdebug.start_with_request=yes
+xdebug.discover_client_host=1


### PR DESCRIPTION
Обновил xdebug.ini и Dockerfile.dev. В конфиге добавил `xdebug.discover_client_host=1`, а в докерфайле пришлось копировать конфиг в cli/, иначе там, судя по всему, перетирался конфиг и дебаггер не включался