### PR TITLE
#1750 style updated for chapter nav links

### DIFF
--- a/resources/views/chapter/show.blade.php
+++ b/resources/views/chapter/show.blade.php
@@ -21,7 +21,7 @@
   {{ Breadcrumbs::render('chapter', $chapter) }}
   <div class="row justify-content-center">
     <div
-      class="sticky-top col-md-12 d-flex {{ $previousChapter->exists ? 'justify-content-between' : 'justify-content-end' }}">
+      class="sticky-lg-top col-md-12 d-flex {{ $previousChapter->exists ? 'justify-content-between' : 'justify-content-end' }}">
       @if ($previousChapter->exists)
         <a class="mr-auto" href="{{ route('chapters.show', $previousChapter) }}">@lang('chapter.show.previous_chapter')</a>
       @endif


### PR DESCRIPTION
Поправил стили для этого блока. Теперь в десктопе все так же, а в мобилке ссылки зафиксированы на месте
<img width="1236" height="731" alt="image" src="https://github.com/user-attachments/assets/9eccf2e3-7910-4055-b32c-608c7c96b554" />
<img width="933" height="707" alt="image" src="https://github.com/user-attachments/assets/dd08dd19-9beb-41a0-885c-ea406829b407" />
