### PR TITLE
#1745 remove line highlight in code editor

### DIFF
--- a/resources/js/components/EditorBuilder.jsx
+++ b/resources/js/components/EditorBuilder.jsx
@@ -15,13 +15,13 @@ import { lineNumbers,
   dropCursor,
   rectangularSelection,
   crosshairCursor,
-  keymap } from '@codemirror/view';
+  keymap, } from '@codemirror/view';
 import { foldGutter,
   indentOnInput,
   syntaxHighlighting,
   defaultHighlightStyle,
   bracketMatching,
-  foldKeymap } from '@codemirror/language';
+  foldKeymap, } from '@codemirror/language';
 
 import { EditorState } from '@codemirror/state'
 import { StreamLanguage } from '@codemirror/language'

--- a/resources/js/components/EditorBuilder.jsx
+++ b/resources/js/components/EditorBuilder.jsx
@@ -3,7 +3,26 @@ import React, {
 } from 'react'
 
 import { useDispatch, useSelector } from 'react-redux'
-import { EditorView, basicSetup } from 'codemirror'
+import { EditorView } from 'codemirror'
+import { history, defaultKeymap, historyKeymap } from '@codemirror/commands';
+import { highlightSelectionMatches, searchKeymap } from '@codemirror/search';
+import { closeBrackets, autocompletion, closeBracketsKeymap, completionKeymap } from '@codemirror/autocomplete';
+import { lintKeymap } from '@codemirror/lint';
+import { lineNumbers,
+  highlightActiveLineGutter,
+  highlightSpecialChars,
+  drawSelection,
+  dropCursor,
+  rectangularSelection,
+  crosshairCursor,
+  keymap } from '@codemirror/view';
+import { foldGutter,
+  indentOnInput,
+  syntaxHighlighting,
+  defaultHighlightStyle,
+  bracketMatching,
+  foldKeymap } from '@codemirror/language';
+
 import { EditorState } from '@codemirror/state'
 import { StreamLanguage } from '@codemirror/language'
 import { scheme } from '@codemirror/legacy-modes/mode/scheme'
@@ -15,6 +34,34 @@ import codeTemplates from '../common/codeTemplates.js'
 import theme from '../common/currentTheme'
 
 const myTheme = theme === 'dark' ? basicDark : basicLight
+
+const basicSetup = (() => [
+  lineNumbers(),
+  highlightActiveLineGutter(),
+  highlightSpecialChars(),
+  history(),
+  foldGutter(),
+  drawSelection(),
+  dropCursor(),
+  EditorState.allowMultipleSelections.of(true),
+  indentOnInput(),
+  syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
+  bracketMatching(),
+  closeBrackets(),
+  autocompletion(),
+  rectangularSelection(),
+  crosshairCursor(),
+  highlightSelectionMatches(),
+  keymap.of([
+    ...closeBracketsKeymap,
+    ...defaultKeymap,
+    ...searchKeymap,
+    ...historyKeymap,
+    ...foldKeymap,
+    ...completionKeymap,
+    ...lintKeymap
+  ])
+])();
 
 const EditorBuilder = () => {
   const { focusesCount } = useSelector(state => state.editor)

--- a/resources/js/components/EditorBuilder.jsx
+++ b/resources/js/components/EditorBuilder.jsx
@@ -4,10 +4,10 @@ import React, {
 
 import { useDispatch, useSelector } from 'react-redux'
 import { EditorView } from 'codemirror'
-import { history, defaultKeymap, historyKeymap } from '@codemirror/commands';
-import { highlightSelectionMatches, searchKeymap } from '@codemirror/search';
-import { closeBrackets, autocompletion, closeBracketsKeymap, completionKeymap } from '@codemirror/autocomplete';
-import { lintKeymap } from '@codemirror/lint';
+import { history, defaultKeymap, historyKeymap } from '@codemirror/commands'
+import { highlightSelectionMatches, searchKeymap } from '@codemirror/search'
+import { closeBrackets, autocompletion, closeBracketsKeymap, completionKeymap } from '@codemirror/autocomplete'
+import { lintKeymap } from '@codemirror/lint'
 import { lineNumbers,
   highlightActiveLineGutter,
   highlightSpecialChars,
@@ -15,13 +15,13 @@ import { lineNumbers,
   dropCursor,
   rectangularSelection,
   crosshairCursor,
-  keymap, } from '@codemirror/view';
+  keymap } from '@codemirror/view'
 import { foldGutter,
   indentOnInput,
   syntaxHighlighting,
   defaultHighlightStyle,
   bracketMatching,
-  foldKeymap, } from '@codemirror/language';
+  foldKeymap } from '@codemirror/language'
 
 import { EditorState } from '@codemirror/state'
 import { StreamLanguage } from '@codemirror/language'
@@ -59,9 +59,9 @@ const basicSetup = (() => [
     ...historyKeymap,
     ...foldKeymap,
     ...completionKeymap,
-    ...lintKeymap
-  ])
-])();
+    ...lintKeymap,
+  ]),
+])()
 
 const EditorBuilder = () => {
   const { focusesCount } = useSelector(state => state.editor)


### PR DESCRIPTION
Убрал выделение строки. Сам basicSetup в codemirror не кастомизируется.
Они так и пишут в файле - 

> This extension does not allow customization. The idea is that,
> once you decide you want to configure your editor more precisely,
> you take this package's source (which is just a bunch of imports
> and an array literal), copy it into your own code, and adjust it
> as desired.

Поэтому я вынес импорты экстеншенов и убрал тот, который отвечает за выделение активной строки
<img width="732" height="430" alt="image" src="https://github.com/user-attachments/assets/8812fde8-74e4-44b7-97d0-d0bacd1bcf2f" />
