### PR TITLE
#1739 safe markdown to html enabled

### DIFF
--- a/app/Helpers/MarkdownHelper.php
+++ b/app/Helpers/MarkdownHelper.php
@@ -8,6 +8,6 @@ class MarkdownHelper
 {
     public static function text(string $text): string
     {
-        return (new Parsedown())->text($text);
+        return (new Parsedown())->setSafeMode(true)->text($text);
     }
 }

--- a/resources/views/comment/index.blade.php
+++ b/resources/views/comment/index.blade.php
@@ -31,7 +31,7 @@
                   @endif
                 </td>
 
-                <td class="text-break">{!! strip_tags(MarkdownHelper::text($comment->content)) !!}</td>
+                <td class="text-break">{!! MarkdownHelper::text($comment->content) !!}</td>
 
                 <td>
                   <a href="{{ $comment->present()->getLink() }}">

--- a/resources/views/components/comment/_comment.blade.php
+++ b/resources/views/components/comment/_comment.blade.php
@@ -28,7 +28,7 @@
         <div class="small text-muted ml-2">{{ $comment->parent->content }}</div>
       </div>
     @endif
-    <div class="my-2 text-break">{{ MarkdownHelper::text($comment->content) }}</div>
+    <div class="my-2 text-break">{!! MarkdownHelper::text($comment->content) !!}</div>
     <div>
       @can('reply', $comment)
         <button data-bs-toggle="modal" data-bs-target="#reply-modal-{{ $comment->id }}"

--- a/resources/views/home/index.blade.php
+++ b/resources/views/home/index.blade.php
@@ -173,7 +173,7 @@
               </strong>
               <a href="{{ $comment->present()->getLink() }}">{{ $comment->created_at }}</a>
             </div>
-            <span>{!! strip_tags(MarkdownHelper::text(str_limit($comment->content, 80))) !!}</span>
+            <span>{!! MarkdownHelper::text(str_limit($comment->content, 80)) !!}</span>
           </div>
         </div>
       @endforeach

--- a/resources/views/user/comment/index.blade.php
+++ b/resources/views/user/comment/index.blade.php
@@ -35,7 +35,7 @@
                     </a>
                   @endif
                 </td>
-                <td>{!! strip_tags(MarkdownHelper::text($comment->content, 80)) !!}</td>
+                <td>{!! MarkdownHelper::text($comment->content) !!}</td>
                 <td>{{ $comment->created_at->format('Y-m-d') }}</td>
               </tr>
             @endforeach


### PR DESCRIPTION
Включил safeMode для компонента Parsedown (парсит маркдаун в html) и убрал экранирование тегов при выводе. По идее это защищает от xss  и позволяет отображать маркдаун на страницах
<img width="912" height="489" alt="image" src="https://github.com/user-attachments/assets/490f7b3c-7348-4d61-b21d-86ec24e9adc7" />
