### PR TITLE
feat(ci): add GitHub Actions Version Updater launcher

### DIFF
--- a/.github/workflows/gh-actions-version-updater.yml
+++ b/.github/workflows/gh-actions-version-updater.yml
@@ -1,0 +1,14 @@
+---
+name: GitHub Actions Version Updater (launcher)
+on:
+  schedule:
+    - cron: 0 10 * * 1  # понедельник 10:00 UTC
+  workflow_dispatch: {}
+jobs:
+  call:
+    uses: Hexlet/.github/workflows/gh-actions-version-updater.yml@main
+    secrets:
+      WORKFLOW_SECRET: ${{ secrets.WORKFLOW_SECRET }}
+    permissions:
+      contents: write
+      pull-requests: write


### PR DESCRIPTION
В рамках перехода с [Dependabot](https://github.com/dependabot) на [GitHub Actions Version Updater](https://github.com/marketplace/actions/github-actions-version-updater#usage) добавил конфиг лаунчера для еженедельного запуска проверки обновлений версий зависимостей

> [!IMPORTANT]
> [Связанный ПР](https://github.com/Hexlet/.github/pull/5) 
