### PR TITLE
fix: fix xdebug connection to IDE from Docker container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
     depends_on:
       - database
     command: ["make", "start-app"]
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   frontend:
     build:
@@ -21,6 +23,8 @@ services:
     ports:
       - 5173:5173
     command: ["make", "start-frontend"]
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   database:
     image: postgres:18-alpine

--- a/xdebug.ini
+++ b/xdebug.ini
@@ -3,4 +3,5 @@ error_reporting=E_ALL
 [xdebug]
 xdebug.mode=develop,debug
 xdebug.start_with_request=yes
-xdebug.discover_client_host=1
+xdebug.client_host=host.docker.internal
+xdebug.client_port=9003


### PR DESCRIPTION
## Summary

- Replace `xdebug.discover_client_host=1` with explicit `xdebug.client_host=host.docker.internal` so XDebug targets the host machine, not the container itself
- Add `extra_hosts: host.docker.internal:host-gateway` to `application` and `frontend` services in `docker-compose.yml` so the alias resolves to the Docker bridge gateway IP on Linux

## Test plan

- [ ] Run `docker compose up --build`
- [ ] Enter the container: `docker compose exec application bash`
- [ ] Confirm `host.docker.internal` resolves: `ping -c1 host.docker.internal`
- [ ] Make a request with a breakpoint set in the IDE — XDebug should connect without "Could not connect" errors in the logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)