### PR TITLE
fix: replace getExtraProperty() with getProperty() for activitylog v5

### DIFF
--- a/app/Models/Activity.php
+++ b/app/Models/Activity.php
@@ -25,7 +25,7 @@ class Activity extends BaseActivity
 
     public function getDescription(): string
     {
-        $itemsCount = $this->getExtraProperty('count');
+        $itemsCount = $this->getProperty('count');
         $description = $this->description;
         return trans_choice("activitylog.action_{$description}", $itemsCount, ['count' => $itemsCount]);
     }

--- a/resources/views/home/index.blade.php
+++ b/resources/views/home/index.blade.php
@@ -93,26 +93,26 @@
                   <a href="{{ route('users.show', $logItem->causer->id) }}">{{ $logItem->causer->name }}</a>
                 @endif
               </strong>
-              <a href="{{ $logItem->getExtraProperty('url') ?? '#' }}">{{ $logItem->created_at }}</a>
+              <a href="{{ $logItem->getProperty('url') ?? '#' }}">{{ $logItem->created_at }}</a>
             </div>
             @switch($logItem->description)
               @case('completed_exercise')
                 {{ $logItem->getDescription() }}
-                <a href="{{ route('exercises.show', $logItem->getExtraProperty('exercise_id')) }}">
+                <a href="{{ route('exercises.show', $logItem->getProperty('exercise_id')) }}">
                   {{ $logItem->subject->getFullTitle() }}
                 </a>
               @break
 
               @case('destroy_exercise')
                 {{ $logItem->getDescription() }}
-                <a href="{{ route('exercises.show', $logItem->getExtraProperty('exercise_id')) }}">
+                <a href="{{ route('exercises.show', $logItem->getProperty('exercise_id')) }}">
                   {{ $logItem->subject->getFullTitle() }}
                 </a>
               @break
 
               @case('commented')
                 {{ $logItem->getDescription() }}.
-                <a href="{{ $logItem->getExtraProperty('url') }}">
+                <a href="{{ $logItem->getProperty('url') }}">
                   <!-- FIXME: add check for null // use soft delete -->
                   {{ $logItem?->subject?->getCommentableName() }}
                 </a>
@@ -120,9 +120,9 @@
 
               @case('add_solution')
                 {{ $logItem->getDescription() }}
-                <a href="{{ route('exercises.show', $logItem->getExtraProperty('exercise_id')) }}">
-                  {{ $logItem->getExtraProperty('exercise_path') }}
-                  {{ App\Models\Exercise::findByPath($logItem->getExtraProperty('exercise_path'))->getTitle() }}
+                <a href="{{ route('exercises.show', $logItem->getProperty('exercise_id')) }}">
+                  {{ $logItem->getProperty('exercise_path') }}
+                  {{ App\Models\Exercise::findByPath($logItem->getProperty('exercise_path'))->getTitle() }}
                 </a>
               @break
 
@@ -134,9 +134,9 @@
                     {{ $logItem->getDescription() }}
                   </a>
                   <div class="collapse" id="collapseExp{{ $logItem->id }}">
-                    @if ($logItem->getExtraProperty('chapters'))
+                    @if ($logItem->getProperty('chapters'))
                       <ul>
-                        @foreach ($logItem->getExtraProperty('chapters') as $chapterPath)
+                        @foreach ($logItem->getProperty('chapters') as $chapterPath)
                           <li>
                             <a href="{{ getChapterOriginLinkForNumber($chapterPath) }}">
                               {{ App\Helpers\ChapterHelper::fullChapterName($chapterPath) }}

--- a/resources/views/log/index.blade.php
+++ b/resources/views/log/index.blade.php
@@ -30,7 +30,7 @@
                     @case('removed')
                       {{ $logItem->getDescription() }}
                       <ul>
-                        @foreach ($logItem->getExtraProperty('chapters') as $chapterPath)
+                        @foreach ($logItem->getProperty('chapters') as $chapterPath)
                           <li>
                             <a href="{{ getChapterOriginLinkForNumber($chapterPath) }}">
                               {{ App\Helpers\ChapterHelper::fullChapterName($chapterPath) }}
@@ -42,30 +42,30 @@
 
                     @case('commented')
                       {{ $logItem->getDescription() }}.
-                      <a href="{{ $logItem->getExtraProperty('url') }}">
+                      <a href="{{ $logItem->getProperty('url') }}">
                         {{ $logItem->subject->getCommentableName() }}
                       </a>
                     @break
 
                     @case('completed_exercise')
                       {{ $logItem->getDescription() }}
-                      <a href="{{ route('exercises.show', $logItem->getExtraProperty('exercise_id')) }}">
+                      <a href="{{ route('exercises.show', $logItem->getProperty('exercise_id')) }}">
                         {{ $logItem->subject->getFullTitle() }}
                       </a>
                     @break
 
                     @case('destroy_exercise')
                       {{ $logItem->getDescription() }}
-                      <a href="{{ route('exercises.show', $logItem->getExtraProperty('exercise_id')) }}">
+                      <a href="{{ route('exercises.show', $logItem->getProperty('exercise_id')) }}">
                         {{ $logItem->subject->getFullTitle() }}
                       </a>
                     @break
 
                     @case('add_solution')
                       {{ $logItem->getDescription() }}
-                      <a href="{{ route('exercises.show', $logItem->getExtraProperty('exercise_id')) }}">
-                        {{ $logItem->getExtraProperty('exercise_path') }}
-                        {{ App\Models\Exercise::findByPath($logItem->getExtraProperty('exercise_path'))->getTitle() }}
+                      <a href="{{ route('exercises.show', $logItem->getProperty('exercise_id')) }}">
+                        {{ $logItem->getProperty('exercise_path') }}
+                        {{ App\Models\Exercise::findByPath($logItem->getProperty('exercise_path'))->getTitle() }}
                       </a>
                     @break
 

--- a/tests/Feature/Http/Controllers/HomeControllerActivityTest.php
+++ b/tests/Feature/Http/Controllers/HomeControllerActivityTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers;
+
+use App\Models\Exercise;
+use App\Services\ActivityService;
+use Database\Seeders\ChaptersTableSeeder;
+use Database\Seeders\ExercisesTableSeeder;
+use Tests\ControllerTestCase;
+
+class HomeControllerActivityTest extends ControllerTestCase
+{
+    public function testHomeRendersWithCompletedExerciseActivity(): void
+    {
+        $this->seed([
+            ChaptersTableSeeder::class,
+            ExercisesTableSeeder::class,
+        ]);
+
+        $exercise = Exercise::first();
+
+        $activityService = new ActivityService();
+        $activityService->logCompletedExercise($this->user, $exercise);
+
+        $response = $this->actingAs($this->user)->get(route('home'));
+
+        $response->assertOk();
+    }
+}


### PR DESCRIPTION
## Summary

- `spatie/laravel-activitylog` v5 renamed `getExtraProperty()` to `getProperty()`, but call sites were not updated
- This caused a `ViewException` on the home page (`/`) when any activity log entries existed
- Replaces all occurrences in `Activity` model and both Blade views (`home/index`, `log/index`)

## Test plan

- [x] Added `HomeControllerActivityTest::testHomeRendersWithCompletedExerciseActivity` — creates a real activity entry and asserts the home page renders without error
- [x] Test was verified to **fail** before the fix and **pass** after
- [x] Full test suite passes (minus pre-existing `CheckController` failure unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)