### PR TITLE
Add Docker ecosystem to Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -69,3 +69,12 @@ updates:
       other-js:
         patterns:
           - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      docker:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

- Add `docker` package ecosystem to `.github/dependabot.yml`
- Dependabot will now track Docker image updates weekly (e.g., `postgres:18-alpine` in docker-compose.yml)
- All Docker images are grouped under a single `docker` group

## Test plan

- [ ] Verify `.github/dependabot.yml` syntax is valid
- [ ] Check GitHub → Insights → Dependency graph → Dependabot to confirm docker ecosystem appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)