### PR TITLE
Run docker containers as non-root ubuntu user

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -47,3 +47,10 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local
 COPY ./xdebug.ini /etc/php/${PHP_VERSION}/cli/conf.d/99-xdebug-custom.ini
 
 ENV PATH=/app/node_modules/.bin/:${PATH}
+
+ARG UID=1000
+ARG GID=1000
+
+RUN groupmod -g ${GID} ubuntu && usermod -u ${UID} -g ${GID} ubuntu
+
+USER ubuntu

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -3,6 +3,9 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.dev
+      args:
+        UID: ${UID:-1000}
+        GID: ${GID:-1000}
     volumes:
       - .:/app
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,12 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.dev
+      args:
+        UID: ${UID:-1000}
+        GID: ${GID:-1000}
     volumes:
       - .:/app:delegated
-      - ~/.bash_history:/home/sicp/.bash_history:delegated
+      - ~/.bash_history:/home/ubuntu/.bash_history:delegated
     ports:
       - "8000:8000"
     depends_on:
@@ -18,6 +21,9 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.dev
+      args:
+        UID: ${UID:-1000}
+        GID: ${GID:-1000}
     volumes:
       - .:/app:delegated
     ports:

--- a/make-compose.mk
+++ b/make-compose.mk
@@ -1,4 +1,4 @@
-BUILD_ARGS:= --build-arg UID=$(shell id -u) --build-arg GID=$(shell id -u)
+BUILD_ARGS:= --build-arg UID=$(shell id -u) --build-arg GID=$(shell id -g)
 
 compose: compose-down compose-setup compose-start
 


### PR DESCRIPTION
## Summary

- `Dockerfile.dev`: добавлены `ARG UID/GID`, `groupmod`/`usermod` подстраивают встроенного пользователя `ubuntu` под UID/GID хоста, добавлена директива `USER ubuntu`
- `docker-compose.yml`: build args `UID`/`GID` из shell-окружения для сервисов `application` и `frontend`; исправлен путь `.bash_history` на `/home/ubuntu/`
- `docker-compose.ci.yml`: те же build args с дефолтом `1000`
- `make-compose.mk`: исправлена опечатка — `GID=$(shell id -g)` вместо `$(shell id -u)`

## Test plan

- [x] `make compose-build` — сборка без ошибок
- [x] `docker compose run --rm application whoami` → `ubuntu`
- [x] После `make compose-setup` файлы `vendor/`, `node_modules/` принадлежат хост-пользователю, а не `root`

🤖 Generated with [Claude Code](https://claude.com/claude-code)