### PR TITLE
Install PHP 8.4 from packages.sury.org instead of ondrej PPA

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,3 +1,5 @@
+# NOTE: PHP 8.4 comes from packages.sury.org, which lags behind new Ubuntu releases.
+# Before bumping this tag, check the codename in https://packages.sury.org/php/dists/
 FROM ubuntu:26.04
 
 WORKDIR /app
@@ -9,9 +11,8 @@ ENV PHP_VERSION=8.4
 ENV NODE_MAJOR=24
 
 RUN apt-get update \
-    && apt-get -y install software-properties-common \
-    && add-apt-repository ppa:ondrej/php \
     && apt-get install -y \
+    ca-certificates \
     make \
     curl \
     gnupg \
@@ -25,12 +26,26 @@ RUN apt-get update \
 
 RUN raco pkg install sicp
 
+# ppa:ondrej/php has been merged into packages.sury.org and has no pocket newer
+# than noble, while the Ubuntu 26.04 archive only ships PHP 8.5.
+RUN set -eu; \
+    . /etc/os-release; \
+    install -d -m 0755 /etc/apt/keyrings; \
+    curl -fsSLo /etc/apt/keyrings/deb.sury.org-php.gpg https://packages.sury.org/php/apt.gpg; \
+    chmod 0644 /etc/apt/keyrings/deb.sury.org-php.gpg; \
+    printf 'Types: deb\nURIs: https://packages.sury.org/php/\nSuites: %s\nComponents: main\nSigned-By: /etc/apt/keyrings/deb.sury.org-php.gpg\n' \
+    "${VERSION_CODENAME}" > /etc/apt/sources.list.d/php.sources
+
+# A separate layer on purpose: when the repository above has no pocket for the
+# base image codename, the build fails here with apt's own explicit
+# "does not have a Release file" instead of an opaque install failure below.
+RUN apt-get update
+
 RUN apt-get install -y \
     php${PHP_VERSION} \
     php${PHP_VERSION}-bcmath \
     php${PHP_VERSION}-exif \
     php${PHP_VERSION}-pdo \
-    php${PHP_VERSION}-pgsql \
     php${PHP_VERSION}-pgsql \
     php${PHP_VERSION}-zip \
     php${PHP_VERSION}-xdebug \


### PR DESCRIPTION
## Проблема

CI на `main` красный с 10 июля: [run 29092735644](https://github.com/hexlet-volunteers/hexlet-sicp/actions/runs/29092735644/job/86361748245) и все последующие, включая PR-CI на dependabot-ветках.

Причина — dependabot-бамп базового образа `ubuntu:24.04` → `ubuntu:26.04` (codename `resolute`) в #1920:

- у `ppa:ondrej/php` **нет pocket'а для `resolute`** — apt получает `404 Not Found` и `E: The repository '... resolute Release' does not have a Release file`, а сам PPA сообщает, что переезжает на `https://packages.sury.org/php/`;
- в архивах Ubuntu 26.04 лежит PHP 8.5, пакета `php8.4` там нет;
- `add-apt-repository` при этом завершается с кодом 0, поэтому сборка падала не там, где сломалось, а на 15 строк ниже — `apt-get install php8.4 …` с `exit code 100` и невнятным `Unable to locate package php8.4`.

## Решение

Остаёмся на LTS `ubuntu:26.04` и PHP 8.4, но берём PHP из `packages.sury.org` — нового дома пакетов ondrej. Там уже опубликован pocket `resolute` с `php8.4` версии `8.4.24-1+0~20260730.53+ubuntu26.04~1` (архитектуры amd64/arm64/armhf).

- репозиторий подключается через отдельный keyring и `Signed-By:` (без глобального доверия в `trusted.gpg.d`), в формате deb822 — однострочный `sources.list` в apt 3.x из 26.04 deprecated;
- кодовое имя берётся из `/etc/os-release`, а не хардкодится, чтобы следующий бамп образа не поставил пакеты от другого релиза;
- `software-properties-common` убран — он ставился только ради `add-apt-repository` (заодно из образа уходят python3 + launchpadlib + dbus/gir);
- `ca-certificates` добавлен явно: раньше он приезжал транзитивно через `software-properties-common`, а теперь нужен до обращения к sury по HTTPS;
- `apt-get update` вынесен в отдельный слой, чтобы при следующем бампе базового образа без соответствующего pocket'а сборка падала с внятной ошибкой apt, а не с загадочным `exit 100` ниже;
- убран дубль `php8.4-pgsql`.

`Dockerfile` и `Dockerfile.stage` делают `INCLUDE+ Dockerfile.dev` и получают фикс автоматически. `COPY xdebug.ini` менять не нужно: пакеты sury собраны из той же Debian-упаковки, раскладка `/etc/php/8.4/…` идентична.

## Проверка

Локальный прогон изменённых слоёв на `ubuntu:26.04`: устанавливается `PHP 8.4.24` из `https://packages.sury.org/php resolute/main`, в `php -m` присутствуют `bcmath curl dom exif mbstring pdo_pgsql pdo_sqlite pgsql sqlite3 xdebug xml zip`, директория `/etc/php/8.4/cli/conf.d/` (цель `COPY xdebug.ini`) на месте.

Дальше зелёный CI на этом PR — то же `make ci`, что и на main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)