### PR TITLE
Fix buildx layer cache in CI workflows

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -27,6 +27,14 @@ jobs:
         run: |
           make ci
 
+      - name: Move Docker cache
+        if: always()
+        run: |
+          if [ -d /tmp/.docker-cache-new ]; then
+            rm -rf /tmp/.docker-cache
+            mv /tmp/.docker-cache-new /tmp/.docker-cache
+          fi
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7
         with:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,6 +14,26 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # Кэш Docker слоёв
+      - name: Cache Docker layers
+        uses: actions/cache@v6
+        with:
+          path: /tmp/.docker-cache
+          key: docker-${{ github.sha }}
+          restore-keys: |
+            docker-
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
       - name: Run CI
         run: |
           make ci
+
+      - name: Move Docker cache
+        if: always()
+        run: |
+          if [ -d /tmp/.docker-cache-new ]; then
+            rm -rf /tmp/.docker-cache
+            mv /tmp/.docker-cache-new /tmp/.docker-cache
+          fi

--- a/.github/workflows/solutions.yml
+++ b/.github/workflows/solutions.yml
@@ -11,10 +11,30 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # Кэш Docker слоёв
+      - name: Cache Docker layers
+        uses: actions/cache@v6
+        with:
+          path: /tmp/.docker-cache
+          key: docker-${{ github.sha }}
+          restore-keys: |
+            docker-
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
       # TODO: use solutions test
       - name: Run CI
         run: |
           make ci
+
+      - name: Move Docker cache
+        if: always()
+        run: |
+          if [ -d /tmp/.docker-cache-new ]; then
+            rm -rf /tmp/.docker-cache
+            mv /tmp/.docker-cache-new /tmp/.docker-cache
+          fi
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -6,6 +6,15 @@ services:
       args:
         UID: ${UID:-1000}
         GID: ${GID:-1000}
+      # Кэш слоёв между прогонами CI. Читаем из директории, восстановленной
+      # actions/cache, пишем в отдельную — иначе экспорт наслаивается на импорт
+      # и кэш растёт неограниченно. Требует драйвер docker-container
+      # (docker/setup-buildx-action), стандартный docker-драйвер не умеет
+      # экспортировать кэш.
+      cache_from:
+        - type=local,src=/tmp/.docker-cache
+      cache_to:
+        - type=local,dest=/tmp/.docker-cache-new,mode=max
     volumes:
       - .:/app
     depends_on:

--- a/make-compose.mk
+++ b/make-compose.mk
@@ -62,14 +62,13 @@ compose-check:
 	docker compose run --rm application make check
 
 ci:
-	export BUILD_ARGS="--cache-from=type=local,src=/tmp/.docker-cache --cache-to=type=local,dest=/tmp/.docker-cache,mode=max"
-	docker compose -f docker-compose.ci.yml -p hexlet-sicp-ci build ${BUILD_ARGS}
+	docker compose -f docker-compose.ci.yml -p hexlet-sicp-ci build
 	docker compose -f docker-compose.ci.yml -p hexlet-sicp-ci run --rm application make setup
 	docker compose -f docker-compose.ci.yml -p hexlet-sicp-ci up --abort-on-container-exit
 	docker compose -f docker-compose.ci.yml -p hexlet-sicp-ci down -v --remove-orphans
 
 ci-solutions:
-	docker compose -f docker-compose.ci.yml -p hexlet-sicp-ci build ${BUILD_ARGS}
+	docker compose -f docker-compose.ci.yml -p hexlet-sicp-ci build
 	docker compose -f docker-compose.ci.yml -p hexlet-sicp-ci run --rm application make install-app test-solutions test-sandbox
 	docker compose -f docker-compose.ci.yml -p hexlet-sicp-ci down -v --remove-orphans
 

--- a/make-compose.mk
+++ b/make-compose.mk
@@ -62,13 +62,13 @@ compose-check:
 	docker compose run --rm application make check
 
 ci:
-	docker compose -f docker-compose.ci.yml -p hexlet-sicp-ci build
+	docker compose -f docker-compose.ci.yml -p hexlet-sicp-ci build ${BUILD_ARGS}
 	docker compose -f docker-compose.ci.yml -p hexlet-sicp-ci run --rm application make setup
 	docker compose -f docker-compose.ci.yml -p hexlet-sicp-ci up --abort-on-container-exit
 	docker compose -f docker-compose.ci.yml -p hexlet-sicp-ci down -v --remove-orphans
 
 ci-solutions:
-	docker compose -f docker-compose.ci.yml -p hexlet-sicp-ci build
+	docker compose -f docker-compose.ci.yml -p hexlet-sicp-ci build ${BUILD_ARGS}
 	docker compose -f docker-compose.ci.yml -p hexlet-sicp-ci run --rm application make install-app test-solutions test-sandbox
 	docker compose -f docker-compose.ci.yml -p hexlet-sicp-ci down -v --remove-orphans
 


### PR DESCRIPTION
## Проблема

Кэш слоёв Docker в CI не работал. В цели `ci` (`make-compose.mk`):

```make
BUILD_ARGS:= --build-arg UID=$(shell id -u) --build-arg GID=$(shell id -g)   # строка 1
...
ci:
	export BUILD_ARGS="--cache-from=type=local,src=/tmp/.docker-cache ..."
	docker compose -f docker-compose.ci.yml -p hexlet-sicp-ci build ${BUILD_ARGS}
```

Строка с `export` — мёртвая, по двум причинам сразу:

1. **Каждая строка рецепта Make — отдельный шелл.** `export` умирал вместе со своим шеллом и до следующей строки не доживал.
2. **`${BUILD_ARGS}` раскрывает Make, а не шелл.** Make подставлял сюда свою переменную из строки 1 (`--build-arg UID=... --build-arg GID=...`), а шелловский `export` на неё не влиял в принципе.

То есть флаги кэша не доезжали до билда никогда. Шаг `actions/cache` сохранял и восстанавливал пустую директорию, образ каждый раз собирался с нуля. CI при этом был зелёный — страдала только скорость, поэтому баг и не всплывал.

Третья, независимая причина, почему подход был нерабочим в принципе: **у `docker compose build` нет флагов `--cache-from`/`--cache-to`** (см. `docker compose build --help`). Даже доехав, они уронили бы билд на unknown flag.

## Решение

- Конфигурация кэша перенесена в `docker-compose.ci.yml` (`build.cache_from` / `build.cache_to`) — единственный рабочий способ для compose.
- Из рецепта `ci` удалена мёртвая строка с `export`. `${BUILD_ARGS}` в командах сохранён — он несёт UID/GID и нужен для прав на бинд-маунте.
- Экспорт идёт в отдельную директорию `/tmp/.docker-cache-new` + шаг `Move cache`. Без этого экспорт наслаивается на импорт и кэш растёт неограниченно.
- `setup-buildx-action` и шаг кэширования добавлены в `pull_request.yml` и `solutions.yml`. Локальный экспорт кэша требует драйвер `docker-container`; штатный `docker`-драйвер его не поддерживает. Заодно кэш появляется там, где он ценнее всего — на PR-сборках.

## Проверка

Round-trip проверен локально на минимальном стенде (compose + `docker-container` билдер):

- экспорт: `exporting cache to client directory` → в `dest` появляются `index.json`, `blobs/`;
- импорт на **чистом** билдере (старый удалён, состояние сброшено): `importing cache manifest from local`, все `RUN`-слои — `CACHED`.

Compose корректно подхватывает текущий buildx-билдер и грузит собранный образ в локальный стор, так что последующие `compose run` работают как раньше.

Финальная проверка — прогон CI на самом этом PR. Первый прогон промахивается по кэшу по определению; смысл смотреть, что шаг экспорта не падает, а выигрыш появится со второго прогона.

## Замечание

`make ci` теперь требует билдер с драйвером `docker-container`. Для цели, названной `ci`, это приемлемо; на локальную разработку (`make compose-setup`, `make compose-test`) не влияет.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
