### PR TITLE
perf(ci): cache composer/npm downloads, key layer cache by Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,6 @@ node_modules
 
 storage/logs
 storage/app
+
+.composer-cache
+.npm-cache

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -16,9 +16,21 @@ jobs:
         uses: actions/cache@v6
         with:
           path: /tmp/.docker-cache
-          key: docker-${{ github.sha }}
+          key: docker-${{ hashFiles('Dockerfile.dev', 'xdebug.ini') }}
           restore-keys: |
             docker-
+
+      # Загрузочные кэши composer и npm. Кэш слоёв их не покрывает:
+      # composer install и npm ci выполняются в рантайме, а не при сборке образа.
+      - name: Cache PHP and JS dependencies
+        uses: actions/cache@v6
+        with:
+          path: |
+            .composer-cache
+            .npm-cache
+          key: deps-${{ hashFiles('composer.lock', 'package-lock.json') }}
+          restore-keys: |
+            deps-
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -19,9 +19,21 @@ jobs:
         uses: actions/cache@v6
         with:
           path: /tmp/.docker-cache
-          key: docker-${{ github.sha }}
+          key: docker-${{ hashFiles('Dockerfile.dev', 'xdebug.ini') }}
           restore-keys: |
             docker-
+
+      # Загрузочные кэши composer и npm. Кэш слоёв их не покрывает:
+      # composer install и npm ci выполняются в рантайме, а не при сборке образа.
+      - name: Cache PHP and JS dependencies
+        uses: actions/cache@v6
+        with:
+          path: |
+            .composer-cache
+            .npm-cache
+          key: deps-${{ hashFiles('composer.lock', 'package-lock.json') }}
+          restore-keys: |
+            deps-
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/solutions.yml
+++ b/.github/workflows/solutions.yml
@@ -16,9 +16,21 @@ jobs:
         uses: actions/cache@v6
         with:
           path: /tmp/.docker-cache
-          key: docker-${{ github.sha }}
+          key: docker-${{ hashFiles('Dockerfile.dev', 'xdebug.ini') }}
           restore-keys: |
             docker-
+
+      # Загрузочные кэши composer и npm. Кэш слоёв их не покрывает:
+      # composer install и npm ci выполняются в рантайме, а не при сборке образа.
+      - name: Cache PHP and JS dependencies
+        uses: actions/cache@v6
+        with:
+          path: |
+            .composer-cache
+            .npm-cache
+          key: deps-${{ hashFiles('composer.lock', 'package-lock.json') }}
+          restore-keys: |
+            deps-
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ _ide_helper_models.php
 public/img/*
 composer.phar
 .phpunit.cache
+
+.composer-cache
+.npm-cache

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -14,7 +14,7 @@ services:
       cache_from:
         - type=local,src=/tmp/.docker-cache
       cache_to:
-        - type=local,dest=/tmp/.docker-cache-new,mode=max
+        - type=local,dest=/tmp/.docker-cache-new,mode=min
     volumes:
       - .:/app
     depends_on:
@@ -24,6 +24,12 @@ services:
       DB_HOST: database
       DB_DATABASE: postgres
       DB_USERNAME: postgres
+      # Загрузочные кэши composer и npm внутри бинд-маунта, а не в $HOME
+      # контейнера — иначе их не видно с хоста и нечего отдавать
+      # actions/cache. node_modules кэшировать бессмысленно: npm ci
+      # удаляет его перед установкой.
+      COMPOSER_CACHE_DIR: /app/.composer-cache
+      npm_config_cache: /app/.npm-cache
     command: ["make", "test-coverage", "analyse", "lint"]
 
   database:


### PR DESCRIPTION
Кэш слоёв покрывает только сборку образа, а composer install и npm ci выполняются в рантайме (исходники прокидываются бинд-маунтом, в Dockerfile.dev установки зависимостей нет). То есть самая дорогая переменная часть прогона не кэшировалась вообще.

- COMPOSER_CACHE_DIR и npm_config_cache направлены в бинд-маунт, чтобы загрузочные кэши были видны с хоста и попадали в actions/cache. node_modules кэшировать бессмысленно: npm ci удаляет его перед установкой, поэтому кэшируется именно download cache.
- Ключ кэша слоёв теперь hashFiles(Dockerfile.dev, xdebug.ini) вместо github.sha. Раньше точного попадания не было никогда, и actions/cache пересохранял запись на каждом прогоне; теперь при неизменном Dockerfile сохранение пропускается.
- mode=min вместо mode=max: Dockerfile одностадийный, промежуточных стадий для экспорта нет.

<!-- Thank you for submitting a pull request! To speed up the review process, please ensure that everything below
is true:

1. This is not a duplicate of an [existing pull request][1].
2. No existing features have been broken without good reason.
3. Your commit messages are detailed.
4. The code style [guidelines][2] have been followed.
5. Documentation has been updated to reflect your changes.
6. Tests have been added or updated to reflect your changes.
7. All tests have passed.

Any questions should be directed to @fey.

---

Replace any "X" below with information about your pull request.
 -->

## Pull request details

<!-- Provide details about your pull request and what it adds, fixes, or changes. -->


## Issues fixed

<!-- Enter the issue numbers resolved by this pull request below, if any. -->

<!-- Example: #123 -->

## Link to demo

<!-- add link to demonstrate your result -->



[1]: https://github.com/{owner}/{repo}/pulls
[2]: https://github.com/{owner}/{repo}/blob/master/.github/CONTRIBUTING.md#code-style
