### PR TITLE
Restore auth guards on dev-login and the admin route group

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,9 +62,11 @@ Docker: команды с префиксом `compose-*` в `make-compose.mk` (�
 
 ## Security
 
-- User Racket/Scheme code is executed inside `racket/sandbox` with strict limits: memory 256 MB, CPU 128 s, network/subprocess/file access blocked.
-- Temp solution files are named with a random identifier and deleted after the check.
+- User Racket/Scheme code is executed inside `racket/sandbox`: `sandbox-memory-limit` 256 MB, `sandbox-eval-limits` 10 s / 128 MB per evaluation, network/subprocess/file access blocked by the default security guard. The process is additionally capped by an external `timeout 20s`.
+- **Known gap (#1936):** those limits apply only inside the evaluator. Student code is spliced into the wrapper module source (`solution_sandbox_wrapper.blade.php`), so input that closes the surrounding forms reaches the file top level, where no security guard applies. There is no OS-level isolation around the `racket` process.
+- **Known gap (#1941):** temp solution files are named from `time()` plus the exercise id — predictable and collision-prone — and are never deleted. There is no scheduled cleanup.
 - Do not add new shell execution paths without equivalent sandboxing.
+- Admin routes are guarded at the route-group level (`auth` + `can:access-admin`), not only in `AdminController::__construct`. Keep it that way: a subclass that overrides the constructor without calling `parent::__construct()` silently loses the gate — that was #1938.
 
 ## Conventions
 

--- a/app/Http/Controllers/Admin/ExportController.php
+++ b/app/Http/Controllers/Admin/ExportController.php
@@ -13,6 +13,7 @@ class ExportController extends AdminController
     public function __construct(
         private readonly AnalyticsExporter $exporter
     ) {
+        parent::__construct();
     }
 
     public function index(Request $request): View

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -32,6 +32,8 @@ class LoginController extends Controller
 
     public function devLogin()
     {
+        abort_unless(app()->environment('local'), 404);
+
         $user = User::admins()->first();
 
         Auth::login($user);

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,7 +17,13 @@ Route::group([
     Route::get('/oauth/yandex/callback', 'Auth\\Social\\YandexController@handleProviderCallback')->name('oauth.yandex-callback');
 
     Auth::routes(['verify' => true]);
-    Route::post('/dev-login', 'Auth\LoginController@devLogin')->name('auth.dev-login');
+
+    // Вход под администратором без пароля — только для локальной разработки.
+    // В production роут не регистрируется вовсе; сам обработчик дополнительно
+    // отдаёт 404 вне local (см. Auth\LoginController::devLogin).
+    if (!app()->environment('production')) {
+        Route::post('/dev-login', 'Auth\LoginController@devLogin')->name('auth.dev-login');
+    }
 
     Route::singleton('my', 'MyController')->only('show');
     Route::namespace('My')->prefix('my')->name('my.')->group(function (): void {
@@ -52,12 +58,19 @@ Route::group([
     Route::resource('comments', 'CommentController')->only('index', 'store', 'update', 'show', 'destroy');
     Route::resource('pages', 'PagesController')->only('show');
 
-    Route::namespace('Admin')->prefix('admin')->name('admin.')->group(function (): void {
-        Route::resource('users', 'UserController')->only('index', 'edit', 'update');
-        Route::resource('comments', 'CommentController')->only('index');
-        Route::resource('solutions', 'SolutionController')->only('index');
-        Route::resource('export', 'ExportController')->only('index', 'store');
-    });
+    // Гварды стоят на группе, а не только в конструкторе AdminController:
+    // наследник, переопределивший конструктор без вызова parent::__construct(),
+    // иначе молча остаётся без проверки прав.
+    Route::namespace('Admin')
+        ->prefix('admin')
+        ->name('admin.')
+        ->middleware(['auth', 'can:access-admin'])
+        ->group(function (): void {
+            Route::resource('users', 'UserController')->only('index', 'edit', 'update');
+            Route::resource('comments', 'CommentController')->only('index');
+            Route::resource('solutions', 'SolutionController')->only('index');
+            Route::resource('export', 'ExportController')->only('index', 'store');
+        });
 
     Route::fallback(function () {
         return response()->view('errors.404', [], 404);

--- a/tests/Feature/Http/Controllers/Admin/CommentControllerTest.php
+++ b/tests/Feature/Http/Controllers/Admin/CommentControllerTest.php
@@ -45,6 +45,6 @@ class CommentControllerTest extends ControllerTestCase
         $this->withExceptionHandling();
         $response = $this->get(route('admin.comments.index'));
 
-        $response->assertStatus(403);
+        $response->assertRedirect(route('login'));
     }
 }

--- a/tests/Feature/Http/Controllers/Admin/ExportControllerTest.php
+++ b/tests/Feature/Http/Controllers/Admin/ExportControllerTest.php
@@ -11,6 +11,15 @@ class ExportControllerTest extends TestCase
 {
     use RefreshDatabase;
 
+    private User $adminUser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->adminUser = User::factory()->admin()->create();
+    }
+
     public function testExportUsersCsv(): void
     {
         Storage::disk('local')->deleteDirectory('export');
@@ -19,7 +28,7 @@ class ExportControllerTest extends TestCase
             'points' => 120,
         ]);
 
-        $response = $this->post(route('admin.export.store'), [
+        $response = $this->actingAs($this->adminUser)->post(route('admin.export.store'), [
             'type' => 'users',
         ]);
 
@@ -37,9 +46,10 @@ class ExportControllerTest extends TestCase
             str_getcsv($lines[0])
         );
 
-        $row = str_getcsv($lines[1]);
+        $rows = array_map(str_getcsv(...), array_slice($lines, 1));
+        $row = collect($rows)->firstWhere(fn(array $row): bool => (int) $row[0] === $user->id);
 
-        $this->assertEquals($user->id, (int) $row[0]);
+        $this->assertNotNull($row);
         $this->assertEquals($user->points, (int) $row[1]);
         $this->assertNotEmpty($row[2]);
     }
@@ -48,8 +58,57 @@ class ExportControllerTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
 
-        $this->post(route('admin.export.store'), [
+        $this->actingAs($this->adminUser)->post(route('admin.export.store'), [
             'type' => 'invalid_type',
         ]);
+    }
+
+    public function testStoreAsGuestDenied(): void
+    {
+        $this->withExceptionHandling();
+
+        $response = $this->post(route('admin.export.store'), [
+            'type' => 'users',
+        ]);
+
+        $response->assertRedirect(route('login'));
+    }
+
+    public function testStoreAsRegularUserDenied(): void
+    {
+        $this->withExceptionHandling();
+
+        $response = $this->actingAs(User::factory()->regular()->create())
+            ->post(route('admin.export.store'), [
+                'type' => 'users',
+            ]);
+
+        $response->assertStatus(403);
+    }
+
+    public function testIndexAsGuestDenied(): void
+    {
+        $this->withExceptionHandling();
+
+        $response = $this->get(route('admin.export.index'));
+
+        $response->assertRedirect(route('login'));
+    }
+
+    public function testIndexAsRegularUserDenied(): void
+    {
+        $this->withExceptionHandling();
+
+        $response = $this->actingAs(User::factory()->regular()->create())
+            ->get(route('admin.export.index'));
+
+        $response->assertStatus(403);
+    }
+
+    public function testIndexAsAdmin(): void
+    {
+        $response = $this->actingAs($this->adminUser)->get(route('admin.export.index'));
+
+        $response->assertOk();
     }
 }

--- a/tests/Feature/Http/Controllers/Admin/SolutionControllerTest.php
+++ b/tests/Feature/Http/Controllers/Admin/SolutionControllerTest.php
@@ -45,6 +45,6 @@ class SolutionControllerTest extends ControllerTestCase
         $this->withExceptionHandling();
         $response = $this->get(route('admin.solutions.index'));
 
-        $response->assertStatus(403);
+        $response->assertRedirect(route('login'));
     }
 }

--- a/tests/Feature/Http/Controllers/Admin/UserControllerTest.php
+++ b/tests/Feature/Http/Controllers/Admin/UserControllerTest.php
@@ -44,7 +44,7 @@ class UserControllerTest extends ControllerTestCase
         $this->withExceptionHandling();
         $response = $this->get(route('admin.users.index'));
 
-        $response->assertStatus(403);
+        $response->assertRedirect(route('login'));
     }
 
     public function testUpdateAsAdmin(): void
@@ -105,6 +105,6 @@ class UserControllerTest extends ControllerTestCase
             'is_admin' => true,
         ]);
 
-        $response->assertStatus(403);
+        $response->assertRedirect(route('login'));
     }
 }

--- a/tests/Feature/Http/Controllers/Auth/LoginControllerTest.php
+++ b/tests/Feature/Http/Controllers/Auth/LoginControllerTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Http\Controllers\Auth;
 
 use Tests\TestCase;
+use App\Http\Middleware\VerifyCsrfToken;
 use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 
@@ -51,5 +52,32 @@ class LoginControllerTest extends TestCase
         $this->assertAuthenticated();
 
         $response->assertRedirect($progressUrl);
+    }
+
+    public function testDevLoginIsNotAvailableOutsideLocal(): void
+    {
+        $this->withExceptionHandling();
+
+        User::factory()->admin()->create();
+
+        $response = $this->post(route('auth.dev-login'));
+
+        $response->assertNotFound();
+        $this->assertGuest();
+    }
+
+    public function testDevLoginAuthenticatesAdminInLocal(): void
+    {
+        // Подмена окружения выключает и пропуск CSRF, завязанный на env=testing,
+        // поэтому middleware отключается явно.
+        $this->app['env'] = 'local';
+        $this->withoutMiddleware(VerifyCsrfToken::class);
+
+        $admin = User::factory()->admin()->create();
+
+        $response = $this->from(route('home'))->post(route('auth.dev-login'));
+
+        $response->assertRedirect(route('home'));
+        $this->assertAuthenticatedAs($admin);
     }
 }


### PR DESCRIPTION
## Контекст

Аудит трекера выявил два пути в админку без аутентификации. Оба подтверждены чтением кода, оба воспроизводятся одним анонимным запросом.

## Что было

**#1935 — `/dev-login`.** POST-роут регистрировался в общей locale-группе без гварда окружения, а `LoginController::devLogin()` выполнял `Auth::login(User::admins()->first())` без единой проверки. Скрытие ссылки в `_nav.blade.php` под `@if (app()->environment('local'))` прятало кнопку, но не роут. `middleware('guest')` не мешал — атакующий и так неаутентифицирован, а CSRF-токен берётся с любой публичной страницы.

**#1938 — админский экспорт.** `ExportController extends AdminController`, но переопределял конструктор ради внедрения `AnalyticsExporter` и не вызывал `parent::__construct()` — значит `can:access-admin` для него не регистрировался. Собственных гвардов у группы админских маршрутов не было, так что гейт держался исключительно на конструкторе базового класса. Любой анонимный запрос к `/admin/export` отдавал CSV с полным содержимым датасета: все email пользователей, все решения, комментарии и записи активности.

## Что сделано

- **Роут `dev-login` регистрируется только вне production**, а обработчик дополнительно отдаёт 404 вне `local`. Два независимых слоя: даже если роут когда-нибудь зарегистрируют заново, обработчик не сработает.
- **Гварды `auth` и `can:access-admin` перенесены на группу админских маршрутов.** Вызов `parent::__construct()` в `ExportController` восстановлен как второй слой, но защита больше не зависит от того, что делают конструкторы наследников — а именно это и сломалось.
- **`AGENTS.md`:** раздел Security описывал поведение, которого в коде нет. Исправлены лимиты песочницы (`sandbox-eval-limits` — 10 с / 128 МБ, а не «CPU 128 s») и утверждение про удаление временных файлов. Известные расхождения помечены явно со ссылками на #1936 и #1941, добавлено правило про гварды на группе.

## Изменение поведения

Гость на админских маршрутах теперь получает **редирект на логин вместо 403** — это следствие добавленной `auth`. Соответствующие проверки в `UserControllerTest`, `CommentControllerTest` и `SolutionControllerTest` обновлены.

## Тест, закреплявший уязвимость

`ExportControllerTest::testExportUsersCsv` постил в `admin.export.store` **без аутентификации** и ожидал 200 — то есть фиксировал дыру как ожидаемое поведение. Тест переписан: работает от админа, плюс добавлены проверки отказа гостю и обычному пользователю для `index` и `store`.

## Проверка

- `php artisan test --compact tests/Feature/Http/Controllers/Admin tests/Feature/Http/Controllers/Auth/LoginControllerTest.php` — 23 passed;
- полный `Feature`-набор — 86 тестов, 2 падения в `CheckControllerTest`, оба из-за отсутствия Racket в окружении. Проверено, что они падают и на чистом `main` без этих изменений;
- `make lint-php` — без замечаний.

Closes #1935
Closes #1938

🤖 Generated with [Claude Code](https://claude.com/claude-code)
