### PR TITLE
Address review findings on security headers and cookies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,9 +21,10 @@ CACHE_DRIVER=file
 QUEUE_CONNECTION=sync
 SESSION_DRIVER=file
 SESSION_LIFETIME=120
-# Set to false only for local plain-HTTP development.
-SESSION_SECURE_COOKIE=false
-SESSION_SAME_SITE=lax
+# Session cookies get the Secure flag when APP_ENV is production.
+# Uncomment to pin the flag explicitly.
+# SESSION_SECURE_COOKIE=true
+# SESSION_SAME_SITE=lax
 
 REDIS_HOST=127.0.0.1
 REDIS_PASSWORD=null

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -20,7 +20,11 @@ class Kernel extends HttpKernel
         \App\Http\Middleware\TrimStrings::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
         \App\Http\Middleware\TrustProxies::class,
+        // SecurityHeaders wraps ForceHttps so that the HTTPS redirect carries
+        // the baseline headers too. Both rely on TrustProxies having resolved
+        // the original scheme first.
         \App\Http\Middleware\SecurityHeaders::class,
+        \App\Http\Middleware\ForceHttps::class,
     ];
 
     /**

--- a/app/Http/Middleware/ForceHttps.php
+++ b/app/Http/Middleware/ForceHttps.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class ForceHttps
+{
+    /**
+     * Redirect plaintext production requests to their HTTPS counterpart.
+     *
+     * The original scheme is exposed by Heroku's TLS-terminating router via
+     * `X-Forwarded-Proto`, which `TrustProxies` maps onto
+     * `$request->isSecure()` — hence this middleware must run after it.
+     *
+     * The redirect uses 308 rather than 301 so that the method and body of
+     * non-GET requests survive it, and so browsers do not cache it forever.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (app()->environment('production') && !$request->isSecure()) {
+            return redirect()->secure($request->getRequestUri(), 308);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -9,27 +9,26 @@ use Symfony\Component\HttpFoundation\Response;
 class SecurityHeaders
 {
     /**
-     * Handle an incoming request: force HTTPS in production and attach
-     * a baseline set of security headers to every response.
+     * Attach a baseline set of security headers to every response.
+     *
+     * `Strict-Transport-Security` is only meaningful over TLS, so it is sent
+     * on secure responses alone. Behind Heroku's TLS-terminating router the
+     * original scheme reaches the app via `X-Forwarded-Proto`, which
+     * `TrustProxies` maps onto `$request->isSecure()`.
+     *
+     * `X-XSS-Protection` is pinned to `0`: the legacy auditor can itself
+     * introduce vulnerabilities, so OWASP recommends disabling it in favour
+     * of a Content-Security-Policy.
      *
      * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
      */
     public function handle(Request $request, Closure $next): Response
     {
-        // Behind Heroku's TLS-terminating router the original scheme is
-        // exposed via X-Forwarded-Proto, which TrustProxies maps onto
-        // $request->isSecure(). Redirect plaintext requests to HTTPS.
-        if (app()->environment('production') && !$request->isSecure()) {
-            return redirect()->secure($request->getRequestUri(), 301);
-        }
-
         $response = $next($request);
 
         $headers = [
             'Referrer-Policy' => 'strict-origin-when-cross-origin',
             'Permissions-Policy' => 'camera=(), microphone=(), geolocation=()',
-            // The legacy auditor can itself introduce vulnerabilities; OWASP
-            // recommends disabling it in favour of a Content-Security-Policy.
             'X-XSS-Protection' => '0',
         ];
 

--- a/config/session.php
+++ b/config/session.php
@@ -166,7 +166,7 @@ return [
     |
     */
 
-    'secure' => env('SESSION_SECURE_COOKIE', true),
+    'secure' => env('SESSION_SECURE_COOKIE', env('APP_ENV') === 'production'),
 
     /*
     |--------------------------------------------------------------------------

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,5 +1,4 @@
 add_header X-Frame-Options "SAMEORIGIN";
-add_header X-XSS-Protection "1; mode=block";
 add_header X-Content-Type-Options "nosniff";
 
 index  index.php index.html index.htm;

--- a/tests/Feature/Http/Middleware/ForceHttpsTest.php
+++ b/tests/Feature/Http/Middleware/ForceHttpsTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Feature\Http\Middleware;
+
+use Illuminate\Support\Facades\Route;
+use Tests\TestCase;
+
+class ForceHttpsTest extends TestCase
+{
+    private const PROBE_PATH = '/__middleware-probe';
+
+    private string $productionUrl;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Route::middleware('web')->get(self::PROBE_PATH, fn() => 'ok');
+        Route::middleware('web')->post(self::PROBE_PATH, fn() => 'ok');
+
+        $this->productionUrl = config('app.production_url');
+    }
+
+    public function testPlaintextRequestIsRedirectedToHttpsInProduction(): void
+    {
+        $this->runInProduction();
+
+        $response = $this->get($this->plaintextProductionUrl());
+
+        $response->assertStatus(308);
+        $response->assertRedirect($this->productionUrl . self::PROBE_PATH);
+    }
+
+    public function testRedirectPreservesNonGetRequests(): void
+    {
+        $this->runInProduction();
+
+        $response = $this->post($this->plaintextProductionUrl());
+
+        // 308, unlike 301, forbids the client from downgrading POST to GET.
+        $response->assertStatus(308);
+    }
+
+    public function testRedirectCarriesTheBaselineSecurityHeaders(): void
+    {
+        $this->runInProduction();
+
+        $response = $this->get($this->plaintextProductionUrl());
+
+        $response->assertHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
+        $response->assertHeader('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
+        $response->assertHeader('X-XSS-Protection', '0');
+    }
+
+    public function testSecureRequestIsNotRedirectedInProduction(): void
+    {
+        $this->runInProduction();
+
+        $response = $this->get($this->productionUrl . self::PROBE_PATH);
+
+        $response->assertOk();
+    }
+
+    public function testPlaintextRequestIsNotRedirectedOutsideProduction(): void
+    {
+        $response = $this->get('http://localhost' . self::PROBE_PATH);
+
+        $response->assertOk();
+    }
+
+    private function runInProduction(): void
+    {
+        $this->app->detectEnvironment(fn() => 'production');
+    }
+
+    /**
+     * The production host, so that RedirectIfProduction — which runs earlier in
+     * the global stack — lets the request through to ForceHttps.
+     */
+    private function plaintextProductionUrl(): string
+    {
+        return str_replace('https://', 'http://', $this->productionUrl) . self::PROBE_PATH;
+    }
+}

--- a/tests/Feature/Http/Middleware/SecurityHeadersTest.php
+++ b/tests/Feature/Http/Middleware/SecurityHeadersTest.php
@@ -2,17 +2,90 @@
 
 namespace Tests\Feature\Http\Middleware;
 
+use Illuminate\Support\Facades\Route;
+use Symfony\Component\HttpFoundation\Cookie;
 use Tests\TestCase;
 
 class SecurityHeadersTest extends TestCase
 {
+    private const PROBE_PATH = '/__middleware-probe';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Route::middleware('web')->get(self::PROBE_PATH, fn() => 'ok');
+    }
+
     public function testBaselineHeadersArePresent(): void
     {
-        $response = $this->get(route('pages.show', ['page' => 'about']));
+        $response = $this->get('http://localhost' . self::PROBE_PATH);
 
         $response->assertOk();
         $response->assertHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
         $response->assertHeader('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
         $response->assertHeader('X-XSS-Protection', '0');
+    }
+
+    public function testStrictTransportSecurityIsSentOverHttps(): void
+    {
+        $response = $this->get('https://localhost' . self::PROBE_PATH);
+
+        $response->assertOk();
+        $response->assertHeader('Strict-Transport-Security', 'max-age=31536000; includeSubDomains; preload');
+    }
+
+    public function testStrictTransportSecurityIsAbsentOverPlainHttp(): void
+    {
+        $response = $this->get('http://localhost' . self::PROBE_PATH);
+
+        $response->assertOk();
+        $response->assertHeaderMissing('Strict-Transport-Security');
+    }
+
+    public function testSessionCookieIsSecureWhenConfigured(): void
+    {
+        config(['session.secure' => true]);
+
+        $response = $this->get('http://localhost' . self::PROBE_PATH);
+
+        $response->assertOk();
+        $this->assertTrue($this->sessionCookie($response->baseResponse->headers->getCookies())->isSecure());
+    }
+
+    public function testSessionCookieIsNotSecureOutsideProduction(): void
+    {
+        $response = $this->get('http://localhost' . self::PROBE_PATH);
+
+        $response->assertOk();
+        $this->assertFalse(config('session.secure'));
+        $this->assertFalse($this->sessionCookie($response->baseResponse->headers->getCookies())->isSecure());
+    }
+
+    public function testSessionCookieUsesLaxSameSite(): void
+    {
+        $response = $this->get('http://localhost' . self::PROBE_PATH);
+
+        $response->assertOk();
+        $this->assertSame(
+            Cookie::SAMESITE_LAX,
+            $this->sessionCookie($response->baseResponse->headers->getCookies())->getSameSite(),
+        );
+    }
+
+    /**
+     * @param  array<int, Cookie>  $cookies
+     */
+    private function sessionCookie(array $cookies): Cookie
+    {
+        $name = config('session.cookie');
+
+        foreach ($cookies as $cookie) {
+            if ($cookie->getName() === $name) {
+                return $cookie;
+            }
+        }
+
+        $this->fail("Session cookie [{$name}] was not set on the response.");
     }
 }


### PR DESCRIPTION
Правки по ревью #1925. Сам PR был смержен, а этот коммит с ответами на замечания остался лежать локально и никуда не уехал — поднимаю его отдельно.

## Что внутри

- **`nginx.conf`** — убран `X-XSS-Protection: 1; mode=block`. `add_header` в nginx **добавляет** заголовок, а не заменяет, поэтому прод начал бы отдавать одновременно и его, и `0` из middleware.
- **`config/session.php`** — Secure-кука привязана к `APP_ENV`, а не включена принудительно. В прежнем виде она ломала локальную разработку по обычному HTTP и CI.
- **`SecurityHeaders`** разделён на middleware только с заголовками и новый **`ForceHttps`**, порядок выбран так, чтобы редирект тоже несёл базовые заголовки.
- **`ForceHttps`** редиректит с **308**, а не 301: сохраняет метод и тело для не-GET запросов и не кешируется навсегда.
- **`.env.example`** — переменные сессии задокументированы, но без живого `SESSION_SECURE_COOKIE=false`, который `cp -n` сделал бы дефолтом на всех окружениях.
- **Тесты** — покрыты ветки редиректа, HSTS и куки, на отдельном probe-роуте вместо паразитирования на `PagesController`.

## Проверено

- Коммит перенесён cherry-pick'ом на актуальный `main`, конфликтов нет. Ни один из 8 затронутых файлов не менялся в `main` с момента ответвления.
- `tests/Feature/Http/Middleware/` — 11 из 11.
- Остальной `Feature` — 95 из 95 (`--filter` без `CheckControllerTest`).
- `CheckControllerTest:42` падает и на чистом `main` — локально нет `raco`. К этому PR отношения не имеет.

Middleware здесь глобальный, поэтому полный прогон был обязателен, а не формальностью.
